### PR TITLE
chore: bump zlib to 1.2.12

### DIFF
--- a/zlib/pkg.yaml
+++ b/zlib/pkg.yaml
@@ -3,10 +3,10 @@ dependencies:
   - stage: base
 steps:
   - sources:
-      - url: https://zlib.net/zlib-1.2.11.tar.xz
+      - url: https://zlib.net/zlib-1.2.12.tar.xz
         destination: zlib.tar.xz
-        sha256: 4ff941449631ace0d4d203e3483be9dbc9da454084111f97ea0a2114e19bf066
-        sha512: b7f50ada138c7f93eb7eb1631efccd1d9f03a5e77b6c13c8b757017b2d462e19d2d3e01c50fad60a4ae1bc86d431f6f94c72c11ff410c25121e571953017cb67
+        sha256: 7db46b8d7726232a621befaab4a1c870f00a90805511c0e0090441dac57def18
+        sha512: 12940e81e988f7661da52fa20bdc333314ae86a621fdb748804a20840b065a1d6d984430f2d41f3a057de0effc6ff9bcf42f9ee9510b88219085f59cbbd082bd
     prepare:
       - |
         tar -xJf zlib.tar.xz --strip-components=1


### PR DESCRIPTION
Bump zlib to 1.2.12

Fixes: [CVE-2018-25032](https://nvd.nist.gov/vuln/detail/CVE-2018-25032)

Refs:
 - https://github.com/advisories/GHSA-jc36-42cf-vqwj
 - https://github.com/madler/zlib/issues/605

Signed-off-by: Noel Georgi <git@frezbo.dev>