### PR TITLE
chore: bump xz and gzip

### DIFF
--- a/gzip/pkg.yaml
+++ b/gzip/pkg.yaml
@@ -3,10 +3,10 @@ dependencies:
   - stage: base
 steps:
   - sources:
-      - url: https://ftp.gnu.org/gnu/gzip/gzip-1.9.tar.xz
+      - url: https://ftp.gnu.org/gnu/gzip/gzip-1.12.tar.xz
         destination: gzip.tar.xz
-        sha256: ae506144fc198bd8f81f1f4ad19ce63d5a2d65e42333255977cf1dcf1479089a
-        sha512: c0852e7f7662141e79d14bc36e50f1940dba3e804feff3b0b8fa084ffec720ac245352282d2f1db117fadc95758424dd418d192b94621dac4367834ccf101fad
+        sha256: ce5e03e519f637e1f814011ace35c4f87b33c0bbabeec35baf5fbd3479e91956
+        sha512: 116326fe991828227de150336a0c016f4fe932dfbb728a16b4a84965256d9929574a4f5cfaf3cf6bb4154972ef0d110f26ab472c93e62ec9a5fd7a5d65abea24
     prepare:
       - |
         tar -xJf gzip.tar.xz --strip-components=1

--- a/xz/patches/xzgrep-ZDI-CAN-16587.patch
+++ b/xz/patches/xzgrep-ZDI-CAN-16587.patch
@@ -1,0 +1,93 @@
+From 69d1b3fc29677af8ade8dc15dba83f0589cb63d6 Mon Sep 17 00:00:00 2001
+From: Lasse Collin <lasse.collin@tukaani.org>
+Date: Tue, 29 Mar 2022 19:19:12 +0300
+Subject: [PATCH] xzgrep: Fix escaping of malicious filenames (ZDI-CAN-16587).
+
+Malicious filenames can make xzgrep to write to arbitrary files
+or (with a GNU sed extension) lead to arbitrary code execution.
+
+xzgrep from XZ Utils versions up to and including 5.2.5 are
+affected. 5.3.1alpha and 5.3.2alpha are affected as well.
+This patch works for all of them.
+
+This bug was inherited from gzip's zgrep. gzip 1.12 includes
+a fix for zgrep.
+
+The issue with the old sed script is that with multiple newlines,
+the N-command will read the second line of input, then the
+s-commands will be skipped because it's not the end of the
+file yet, then a new sed cycle starts and the pattern space
+is printed and emptied. So only the last line or two get escaped.
+
+One way to fix this would be to read all lines into the pattern
+space first. However, the included fix is even simpler: All lines
+except the last line get a backslash appended at the end. To ensure
+that shell command substitution doesn't eat a possible trailing
+newline, a colon is appended to the filename before escaping.
+The colon is later used to separate the filename from the grep
+output so it is fine to add it here instead of a few lines later.
+
+The old code also wasn't POSIX compliant as it used \n in the
+replacement section of the s-command. Using \<newline> is the
+POSIX compatible method.
+
+LC_ALL=C was added to the two critical sed commands. POSIX sed
+manual recommends it when using sed to manipulate pathnames
+because in other locales invalid multibyte sequences might
+cause issues with some sed implementations. In case of GNU sed,
+these particular sed scripts wouldn't have such problems but some
+other scripts could have, see:
+
+    info '(sed)Locale Considerations'
+
+This vulnerability was discovered by:
+cleemy desu wayo working with Trend Micro Zero Day Initiative
+
+Thanks to Jim Meyering and Paul Eggert discussing the different
+ways to fix this and for coordinating the patch release schedule
+with gzip.
+---
+ src/scripts/xzgrep.in | 20 ++++++++++++--------
+ 1 file changed, 12 insertions(+), 8 deletions(-)
+
+diff --git a/src/scripts/xzgrep.in b/src/scripts/xzgrep.in
+index b180936..e5186ba 100644
+--- a/src/scripts/xzgrep.in
++++ b/src/scripts/xzgrep.in
+@@ -180,22 +180,26 @@ for i; do
+          { test $# -eq 1 || test $no_filename -eq 1; }; then
+       eval "$grep"
+     else
++      # Append a colon so that the last character will never be a newline
++      # which would otherwise get lost in shell command substitution.
++      i="$i:"
++
++      # Escape & \ | and newlines only if such characters are present
++      # (speed optimization).
+       case $i in
+       (*'
+ '* | *'&'* | *'\'* | *'|'*)
+-        i=$(printf '%s\n' "$i" |
+-            sed '
+-              $!N
+-              $s/[&\|]/\\&/g
+-              $s/\n/\\n/g
+-            ');;
++        i=$(printf '%s\n' "$i" | LC_ALL=C sed 's/[&\|]/\\&/g; $!s/$/\\/');;
+       esac
+-      sed_script="s|^|$i:|"
++
++      # $i already ends with a colon so don't add it here.
++      sed_script="s|^|$i|"
+ 
+       # Fail if grep or sed fails.
+       r=$(
+         exec 4>&1
+-        (eval "$grep" 4>&-; echo $? >&4) 3>&- | sed "$sed_script" >&3 4>&-
++        (eval "$grep" 4>&-; echo $? >&4) 3>&- |
++            LC_ALL=C sed "$sed_script" >&3 4>&-
+       ) || r=2
+       exit $r
+     fi >&3 5>&-
+-- 
+2.35.1

--- a/xz/pkg.yaml
+++ b/xz/pkg.yaml
@@ -1,18 +1,29 @@
 name: xz
 dependencies:
   - stage: base
+  - stage: patch
+  - stage: autoconf
+  - stage: automake
+  - stage: gettext
+  - stage: libtool
 steps:
   - sources:
-      - url: http://deb.debian.org/debian/pool/main/x/xz-utils/xz-utils_5.2.4.orig.tar.xz
-        destination: xz.tar.xz
-        sha256: 9717ae363760dedf573dad241420c5fea86256b65bc21d2cf71b2b12f0544f4b
-        sha512: 00db7dd31a61541b1ce6946e0f21106f418dd1ac3f27cdb8682979cbc3bd777cd6dd1f04f9ba257a0a7e24041e15ca40d0dd5c130380dce62280af67a0beb97f
+      - url: https://github.com/xz-mirror/xz/archive/refs/tags/v5.2.5.tar.gz
+        destination: xz.tar.gz
+        sha256: 0d2b89629f13dd1a0602810529327195eff5f62a0142ccd65b903bc16a4ac78a
+        sha512: 686f01cfe33e2194766a856c48668c661b25eee194a443524f87ce3f866e0eb54914075b4e00185921516c5211db8cd5d2658f4b91f4a3580508656f776f468e
     prepare:
       - |
-        tar -xJf xz.tar.xz --strip-components=1
-        mkdir build
-        cd build
-        ../configure \
+        mkdir -p xz build
+
+        tar -xf xz.tar.gz --strip-components=1 -C xz
+
+        cd xz
+        patch -p1 < /pkg/patches/xzgrep-ZDI-CAN-16587.patch
+        ./autogen.sh --no-po4a
+
+        cd ../build
+        ../xz/configure \
             --prefix=${TOOLCHAIN}
     build:
       - |


### PR DESCRIPTION
Bump xz to 5.2.5 and gzip to 1.12

Fixes CVE-2022-1271, ZDI-CAN-16587

```text
5.2.5 was released on 2020-03-17. A patch to fix a security vulnerability in xzgrep (CVE-2022-1271, ZDI-CAN-16587) was made public on 2022-04-07. It is a severe issue if an attacker can control the filenames that are given on the xzgrep command line.
```

Ref:
 - https://tukaani.org/xz/
 - https://www.openwall.com/lists/oss-security/2022/04/07/8

Signed-off-by: Noel Georgi <git@frezbo.dev>