### PR TITLE
chore: bump go to 1.18.1

### DIFF
--- a/golang/golang/pkg.yaml
+++ b/golang/golang/pkg.yaml
@@ -4,10 +4,10 @@ dependencies:
   - stage: '{{ if eq .ARCH "aarch64" }}golang-alpine{{ else }}golang-bootstrap{{ end }}'
 steps:
   - sources:
-      - url: https://dl.google.com/go/go1.18.src.tar.gz
+      - url: https://dl.google.com/go/go1.18.1.src.tar.gz
         destination: go.src.tar.gz
-        sha256: 38f423db4cc834883f2b52344282fa7a39fbb93650dc62a11fdf0be6409bdad6
-        sha512: f10356df9099e4d027415be5c73bd2551f2f941a31feb21e1ccc03b7d8faa1844f0a639a508e990712e11ec335675e57504edb323fa1eee63e1d09b8523b3b0d
+        sha256: efd43e0f1402e083b73a03d444b7b6576bb4c539ac46208b63a916b69aca4088
+        sha512: baa053e2d713b235b9285c946b4f0842085a5224d1f4cbe92a446fbf97ed9f7289c8d4ba212fb31dd2e4eac39bb4c015f478543a1856594c2d1fc331c946f571
 
     env:
       GOROOT_BOOTSTRAP: '{{ .TOOLCHAIN }}/go_bootstrap'

--- a/zlib/pkg.yaml
+++ b/zlib/pkg.yaml
@@ -3,13 +3,13 @@ dependencies:
   - stage: base
 steps:
   - sources:
-      - url: https://zlib.net/zlib-1.2.12.tar.xz
-        destination: zlib.tar.xz
-        sha256: 7db46b8d7726232a621befaab4a1c870f00a90805511c0e0090441dac57def18
-        sha512: 12940e81e988f7661da52fa20bdc333314ae86a621fdb748804a20840b065a1d6d984430f2d41f3a057de0effc6ff9bcf42f9ee9510b88219085f59cbbd082bd
+      - url: https://zlib.net/fossils/zlib-1.2.12.tar.gz
+        destination: zlib.tar.gz
+        sha256: 91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9
+        sha512: cc2366fa45d5dfee1f983c8c51515e0cff959b61471e2e8d24350dea22d3f6fcc50723615a911b046ffc95f51ba337d39ae402131a55e6d1541d3b095d6c0a14
     prepare:
       - |
-        tar -xJf zlib.tar.xz --strip-components=1
+        tar -xf zlib.tar.gz --strip-components=1
         mkdir build
         cd build
 


### PR DESCRIPTION
Bump go to 1.18.1

Fixes:

- [CVE-2022-24675](https://github.com/golang/go/issues/51853)
- [CVE-2022-28327](https://github.com/golang/go/issues/52075)
- [CVE-2022-27536](https://github.com/golang/go/issues/51759)

Also update zlib download url's

Signed-off-by: Noel Georgi <git@frezbo.dev>