### PR TITLE
chore: bump go to 1.17.9

### DIFF
--- a/golang/golang/pkg.yaml
+++ b/golang/golang/pkg.yaml
@@ -4,10 +4,10 @@ dependencies:
   - stage: '{{ if eq .ARCH "aarch64" }}golang-alpine{{ else }}golang-bootstrap{{ end }}'
 steps:
   - sources:
-      - url: https://dl.google.com/go/go1.17.8.src.tar.gz
+      - url: https://dl.google.com/go/go1.17.7.src.tar.gz
         destination: go.src.tar.gz
-        sha256: 2effcd898140da79a061f3784ca4f8d8b13d811fb2abe9dad2404442dabbdf7a
-        sha512: 21d5c51ce62bc3b987dd5bf7c6b7e1a934fe40582bfbbe99ca80c26d41253e796a4b9d02c571f1e5ab3fd7c3950175e23b9929b0d934f421c96a6d6128c44668
+        sha256: c108cd33b73b1911a02b697741df3dea43e01a5c4e08e409e8b3a0e3745d2b4d
+        sha512: ee20a97d19e501ee2c11930548bcacfa8b1e8499bbae15659231548f4b03c13bc92bb20c4ce879f0956c02268e748c73ba56d8b140ce8f134501c33cc8b58d3c
 
     env:
       GOROOT_BOOTSTRAP: '{{ .TOOLCHAIN }}/go_bootstrap'

--- a/zlib/pkg.yaml
+++ b/zlib/pkg.yaml
@@ -3,13 +3,13 @@ dependencies:
   - stage: base
 steps:
   - sources:
-      - url: https://zlib.net/zlib-1.2.11.tar.xz
-        destination: zlib.tar.xz
-        sha256: 4ff941449631ace0d4d203e3483be9dbc9da454084111f97ea0a2114e19bf066
-        sha512: b7f50ada138c7f93eb7eb1631efccd1d9f03a5e77b6c13c8b757017b2d462e19d2d3e01c50fad60a4ae1bc86d431f6f94c72c11ff410c25121e571953017cb67
+      - url: https://zlib.net/fossils/zlib-1.2.11.tar.gz
+        destination: zlib.tar.gz
+        sha256: c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
+        sha512: 73fd3fff4adeccd4894084c15ddac89890cd10ef105dd5e1835e1e9bbb6a49ff229713bd197d203edfa17c2727700fce65a2a235f07568212d820dca88b528ae
     prepare:
       - |
-        tar -xJf zlib.tar.xz --strip-components=1
+        tar -xf zlib.tar.gz --strip-components=1
         mkdir build
         cd build
 


### PR DESCRIPTION
Bump go to 1.17.9

Fixes:

- [CVE-2022-24675](https://github.com/golang/go/issues/51853)
- [CVE-2022-28327](https://github.com/golang/go/issues/52075)
- [CVE-2022-27536](https://github.com/golang/go/issues/51759)

Also update zlib download url's to use proper ones

Signed-off-by: Noel Georgi <git@frezbo.dev>