### PR TITLE
chore: bump util-linux to 2.38

### DIFF
--- a/util-linux/pkg.yaml
+++ b/util-linux/pkg.yaml
@@ -3,10 +3,10 @@ dependencies:
   - stage: base
 steps:
   - sources:
-      - url: https://www.kernel.org/pub/linux/utils/util-linux/v2.32/util-linux-2.32.1.tar.xz
+      - url: https://www.kernel.org/pub/linux/utils/util-linux/v2.38/util-linux-2.38.tar.xz
         destination: util-linux.tar.xz
-        sha256: 86e6707a379c7ff5489c218cfaf1e3464b0b95acf7817db0bc5f179e356a67b2
-        sha512: 267fedae24a874ee4dc558081f6b8d07b33b955b0635f3348f021c111c17f2e95c01b2cbf909fe13c6ca448cbcf23c658c75f72f25749aa65e99f68fabb94698
+        sha256: 6d111cbe4d55b336db2f1fbeffbc65b89908704c01136371d32aa9bec373eb64
+        sha512: d0f7888f457592067938e216695871ce6475a45d83a092cc3fd72b8cf8fca145ca5f3a99122f1744ef60b4f773055cf4e178dc6c59cd30837172aee0b5597e8c
     prepare:
       - |
         tar -xJf util-linux.tar.xz --strip-components=1
@@ -15,7 +15,10 @@ steps:
         ../configure \
             --prefix=${TOOLCHAIN} \
             --without-python \
+            --disable-bash-completion \
+            --disable-asciidoc \
             --disable-makeinstall-chown \
+            --without-systemd \
             --without-systemdsystemunitdir \
             --without-ncurses \
             PKG_CONFIG=""


### PR DESCRIPTION
Bump util-linux to 2.38

Signed-off-by: Noel Georgi <git@frezbo.dev>