### PR TITLE
chore: bump ca-certificates to 2022-04-26

### DIFF
--- a/ca-certificates/pkg.yaml
+++ b/ca-certificates/pkg.yaml
@@ -1,10 +1,10 @@
 name: ca-certificates
 steps:
 - sources:
-  - url: https://curl.se/ca/cacert-2021-10-26.pem
+  - url: https://curl.se/ca/cacert-2022-04-26.pem
     destination: cacert.pem
-    sha256: ae31ecb3c6e9ff3154cb7a55f017090448f88482f0e94ac927c0c67a1f33b9cf
-    sha512: bcc17f23eb54f943c13c6e8b3b0a7e8b72dc9971720249b3eb7a493a66db21d572ba7eedf4f96d8efd6243c3e89f3e258e59ebc9010bce01556b4112ec7d4a3b
+    sha256: 08df40e8f528ed283b0e480ba4bcdbfdd2fdcf695a7ada1668243072d80f8b6f
+    sha512: 91266bcf97d879828c26beba82e15ff73aa676d800e11401da22b0a565e980912222e02e9a9cc7daff7ceddf78309d8fb0adef6a4eaff9cefa73b72a97281bc2
   install:
   - |
     mkdir -p /rootfs${TOOLCHAIN}/etc/ssl/certs


### PR DESCRIPTION
Bump ca-certificates to 2022-04-26

Signed-off-by: Noel Georgi <git@frezbo.dev>