### PR TITLE
chore: stable source date epoch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,10 @@ SHA ?= $(shell git describe --match=none --always --abbrev=8 --dirty)
 TAG ?= $(shell git describe --tag --always --dirty)
 BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 REGISTRY_AND_USERNAME := $(REGISTRY)/$(USERNAME)
-SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct)
+# inital commit time
+# git rev-list --max-parents=0 HEAD
+# git log e2983a47abbfaf9cb1cc740c87af26f29a837ee0 --pretty=%ct
+SOURCE_DATE_EPOCH ?= "1559830076"
 
 # Sync bldr image with Pkgfile
 BLDR ?= docker run --rm --volume $(PWD):/tools --entrypoint=/bldr \

--- a/Pkgfile
+++ b/Pkgfile
@@ -5,7 +5,7 @@
 format: v1alpha2
 
 vars:
-  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v0.5.0-1-g5831f78
+  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v0.5.0-2-g8cbf98a
 
 labels:
   org.opencontainers.image.source: https://github.com/siderolabs/tools


### PR DESCRIPTION
Use the timestamp from repo initial commit as `SOURCE_DATE_EPOCH`

Bump toolchain built with stable [`SOURCE_DATE_EPOCH`](https://github.com/siderolabs/toolchain/pull/35)

Signed-off-by: Noel Georgi <git@frezbo.dev>