### PR TITLE
chore: bump toolchain to v0.6.0

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -5,7 +5,7 @@
 format: v1alpha2
 
 vars:
-  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v0.5.0-2-g8cbf98a
+  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v0.6.0
 
 labels:
   org.opencontainers.image.source: https://github.com/siderolabs/tools


### PR DESCRIPTION
In preparation for Talos 1.1.0-beta.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>