### PR TITLE
chore: bump golang to 1.18.3

### DIFF
--- a/golang/golang/pkg.yaml
+++ b/golang/golang/pkg.yaml
@@ -4,10 +4,10 @@ dependencies:
   - stage: '{{ if eq .ARCH "aarch64" }}golang-alpine{{ else }}golang-bootstrap{{ end }}'
 steps:
   - sources:
-      - url: https://dl.google.com/go/go1.18.2.src.tar.gz
+      - url: https://dl.google.com/go/go1.18.3.src.tar.gz
         destination: go.src.tar.gz
-        sha256: 2c44d03ea2c34092137ab919ba602f2c261a038d08eb468528a3f3a28e5667e2
-        sha512: 9214cbc051cf26b49ab1bd4d8d30b060865944b831578a9ea7fcfe33f84009f77932a39f2948efbfc412b151e4734a3bc1f8332f3bea11b35a912b0e23a4118f
+        sha256: 0012386ddcbb5f3350e407c679923811dbd283fcdc421724931614a842ecbc2d
+        sha512: bacbc74ab8fa4c8de46847cadbd245124491f960c087d6892e2231a73f689d597b9a992c2948c54c0ab4b6476d86d3a6a9a64e1714cb7b2cdfd0a7bcfcd7b5fe
 
     env:
       GOROOT_BOOTSTRAP: '{{ .TOOLCHAIN }}/go_bootstrap'


### PR DESCRIPTION
Fixes:
 - [CVE-2022-30634](https://go.dev/issue/52561)
 - [CVE-2022-30629](https://go.dev/issue/52814)
 - [CVE-2022-30580](https://go.dev/issue/52574)
 - [CVE-2022-29804](https://go.dev/issue/52476)

Signed-off-by: Noel Georgi <git@frezbo.dev>