### PR TITLE
chore: bump golang to 1.17.11

### DIFF
--- a/golang/golang/pkg.yaml
+++ b/golang/golang/pkg.yaml
@@ -4,10 +4,10 @@ dependencies:
   - stage: '{{ if eq .ARCH "aarch64" }}golang-alpine{{ else }}golang-bootstrap{{ end }}'
 steps:
   - sources:
-      - url: https://dl.google.com/go/go1.17.10.src.tar.gz
+      - url: https://dl.google.com/go/go1.17.11.src.tar.gz
         destination: go.src.tar.gz
-        sha256: 299e55af30f15691b015d8dcf8ecae72412412569e5b2ece20361753a456f2f9
-        sha512: 92aa95927ce244cab339dd7f2fb7e416605515d496e96618e6e45ecfa7b022ae3a178bf88338a7a9e9e1afea4c9ab5f9c35f5716409cddbab3542daefb6ba425
+        sha256: ac2649a65944c6a5abe55054000eee3d77196880da36a3555f62e06540e8eb54
+        sha512: cd08062e3357e8e73ad05572ac575b9d8b15599bdb3ea0ca743b04936fa5cca438886e6a06d6453334b8bb5fbe1ab3512657d11651f9199d2254736a6554e71d
 
     env:
       GOROOT_BOOTSTRAP: '{{ .TOOLCHAIN }}/go_bootstrap'


### PR DESCRIPTION
Fixes:
 - [CVE-2022-30634](https://go.dev/issue/52561)
 - [CVE-2022-30629](https://go.dev/issue/52814)
 - [CVE-2022-30580](https://go.dev/issue/52574)
 - [CVE-2022-29804](https://go.dev/issue/52476)

Signed-off-by: Noel Georgi <git@frezbo.dev>