### PR TITLE
chore: bump curl to 7.84.0

### DIFF
--- a/curl/pkg.yaml
+++ b/curl/pkg.yaml
@@ -8,10 +8,10 @@ dependencies:
   - stage: pkg-config
 steps:
   - sources:
-      - url: https://curl.haxx.se/download/curl-7.83.1.tar.xz
+      - url: https://curl.haxx.se/download/curl-7.84.0.tar.xz
         destination: curl.tar.xz
-        sha256: 2cb9c2356e7263a1272fd1435ef7cdebf2cd21400ec287b068396deb705c22c4
-        sha512: 2f63327d6d3687ba36fb7b8d5d3d15599eca33ebfb08681613612ea9c4b629d3b6ce4d2742fa1ebd7a997ed332001d3a4c798985f9277c83b9e7a9aecdb1b1ee
+        sha256: 2d118b43f547bfe5bae806d8d47b4e596ea5b25a6c1f080aef49fbcd817c5db8
+        sha512: 86231866a35593a1637fbc0c6af3b6761bdfd99fb35580cc52970c36f19604f93dce59fea67a1d5bb4b455f719307599c7916c77d14f2b661f6bf7fb1ca716ce
     prepare:
       - |
         tar -xJf curl.tar.xz --strip-components=1


### PR DESCRIPTION
Bump curl to 7.84.0

Fixes:
 - [CVE-2022-32205](https://curl.se/docs/CVE-2022-32205.html)
 - [CVE-2022-32206](https://curl.se/docs/CVE-2022-32206.html)
 - [CVE-2022-32207](https://curl.se/docs/CVE-2022-32207.html)
 - [CVE-2022-32208](https://curl.se/docs/CVE-2022-32208.html)

Signed-off-by: Noel Georgi <git@frezbo.dev>