### PR TITLE
feat: add pahole so kernel can be built with BTF support

### DIFF
--- a/argp-standalone/pkg.yaml
+++ b/argp-standalone/pkg.yaml
@@ -23,7 +23,8 @@ steps:
 
         ./configure \
             --prefix=${TOOLCHAIN} \
-            --disable-static
+            --disable-static \
+            CFLAGS="${CFLAGS} -fPIC"
     build:
       - |
         make -j $(nproc)

--- a/dwarfutils/pkg.yaml
+++ b/dwarfutils/pkg.yaml
@@ -1,0 +1,42 @@
+name: dwarfutils
+dependencies:
+  - stage: base
+  - stage: zlib
+  - stage: elfutils
+steps:
+  - sources:
+      - url: https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/dwarfutils/20210528-1/dwarfutils_20210528.orig.tar.gz
+        destination: dwarfutils.tar.gz
+        sha256: b8ba0ee9b70d2052d45272489d79bf456c4d342fc8c3bba45038afc50ec6e28b
+        sha512: e0f9c88554053ee6c1b1333960891189e7820c4a4ddc302b7e63754a4cdcfc2acb1b4b6083a722d1204a75e994fff3401ecc251b8c3b24090f8cb4046d90f870
+    prepare:
+      - |
+        tar -xvf dwarfutils.tar.gz --strip-components=1
+
+        ./configure --prefix=/usr --enable-shared
+    build:
+      - |
+        make
+    install:
+      - |
+        pushd ./libdwarf
+        install -d /rootfs/usr/include/libdwarf
+        install dwarf.h libdwarf.h /rootfs/usr/include/libdwarf
+        popd
+
+        #libdwarf
+        pushd ./libdwarf/.libs
+        install -d /rootfs/usr/lib
+        install -m 644 libdwarf.a /rootfs/usr/lib
+        install -m 644 libdwarf.so /rootfs/usr/lib
+        popd
+
+        # dwarfdump
+        pushd ./dwarfdump
+        install -Dm755 dwarfdump /rootfs/usr/bin/dwarfdump
+        install -Dm644 dwarfdump.1 /rootfs/usr/share/man/man1/dwarfdump.1
+        install -Dm644 dwarfdump.conf /rootfs/usr/lib/dwarfdump.conf
+        popd
+finalize:
+  - from: /rootfs
+    to: /

--- a/elfutils/patches/libdw-dwarf-frame-register.patch
+++ b/elfutils/patches/libdw-dwarf-frame-register.patch
@@ -1,0 +1,13 @@
+https://www.mail-archive.com/elfutils-devel@sourceware.org/msg02896.html
+--- libdw/dwarf_frame_register.c
++++ libdw/dwarf_frame_register.c
+@@ -34,7 +34,7 @@
+ #include <dwarf.h>
+
+ int
+-dwarf_frame_register (Dwarf_Frame *fs, int regno, Dwarf_Op *ops_mem,
++dwarf_frame_register (Dwarf_Frame *fs, int regno, Dwarf_Op ops_mem[3],
+ 		      Dwarf_Op **ops, size_t *nops)
+ {
+   /* Maybe there was a previous error.  */
+

--- a/elfutils/pkg.yaml
+++ b/elfutils/pkg.yaml
@@ -25,6 +25,7 @@ steps:
         patch -Np0 -i /pkg/patches/elfutils-0.173-musl-qsort_r.patch
         patch -Np0 -i /pkg/patches/elfutils-0.173-musl-strerror_r.patch
         patch -Np0 -i /pkg/patches/elfutils-0.173-musl-strndupa.patch
+        patch -Np0 -i /pkg/patches/libdw-dwarf-frame-register.patch
         autoreconf -if
 
         cp /pkg/files/elfutils-0.173-missingfile-error.h src/error.h
@@ -40,12 +41,12 @@ steps:
     build:
       - |
         cd build
-        make -C lib libeu.a -j $(nproc)
-        make -C libelf -j $(nproc)
+
+        make
     install:
       - |
         cd build
-        make -C libelf DESTDIR=/rootfs install
+        make DESTDIR=/rootfs install
 finalize:
   - from: /rootfs
     to: /

--- a/pahole/patches/libff-to-latest.patch
+++ b/pahole/patches/libff-to-latest.patch
@@ -1,0 +1,92 @@
+https://git.alpinelinux.org/aports/tree/community/pahole/0001-libbpf-Update-libbpf-to-the-latest-git-HEAD.patch
+--- btf_encoder.c
++++ btf_encoder.c
+@@ -172,7 +172,7 @@ __attribute ((format (printf, 5, 6)))
+ static void btf__log_err(const struct btf *btf, int kind, const char *name,
+ 			 bool output_cr, const char *fmt, ...)
+ {
+-	fprintf(stderr, "[%u] %s %s", btf__get_nr_types(btf) + 1,
++	fprintf(stderr, "[%u] %s %s", btf__type_cnt(btf),
+ 		btf_kind_str[kind], name ?: "(anon)");
+
+ 	if (fmt && *fmt) {
+@@ -203,7 +203,7 @@ static void btf_encoder__log_type(const struct btf_encoder *encoder, const struc
+ 	out = err ? stderr : stdout;
+
+ 	fprintf(out, "[%u] %s %s",
+-		btf__get_nr_types(btf), btf_kind_str[kind],
++		btf__type_cnt(btf) - 1, btf_kind_str[kind],
+ 		btf__printable_name(btf, t->name_off));
+
+ 	if (fmt && *fmt) {
+@@ -449,10 +449,10 @@ static int btf_encoder__add_field(struct btf_encoder *encoder, const char *name,
+ 	int err;
+
+ 	err = btf__add_field(btf, name, type, offset, bitfield_size);
+-	t = btf__type_by_id(btf, btf__get_nr_types(btf));
++	t = btf__type_by_id(btf, btf__type_cnt(btf) - 1);
+ 	if (err) {
+ 		fprintf(stderr, "[%u] %s %s's field '%s' offset=%u bit_size=%u type=%u Error emitting field\n",
+-			btf__get_nr_types(btf), btf_kind_str[btf_kind(t)],
++			btf__type_cnt(btf) - 1, btf_kind_str[btf_kind(t)],
+ 			btf__printable_name(btf, t->name_off),
+ 			name, offset, bitfield_size, type);
+ 	} else {
+@@ -899,9 +899,9 @@ static int btf_encoder__write_raw_file(struct btf_encoder *encoder)
+ 	const void *raw_btf_data;
+ 	int fd, err;
+
+-	raw_btf_data = btf__get_raw_data(encoder->btf, &raw_btf_size);
++	raw_btf_data = btf__raw_data(encoder->btf, &raw_btf_size);
+ 	if (raw_btf_data == NULL) {
+-		fprintf(stderr, "%s: btf__get_raw_data failed!\n", __func__);
++		fprintf(stderr, "%s: btf__raw_data failed!\n", __func__);
+ 		return -1;
+ 	}
+
+@@ -976,7 +976,7 @@ static int btf_encoder__write_elf(struct btf_encoder *encoder)
+ 		}
+ 	}
+
+-	raw_btf_data = btf__get_raw_data(btf, &raw_btf_size);
++	raw_btf_data = btf__raw_data(btf, &raw_btf_size);
+
+ 	if (btf_data) {
+ 		/* Existing .BTF section found */
+@@ -1043,10 +1043,10 @@ int btf_encoder__encode(struct btf_encoder *encoder)
+ 		btf_encoder__add_datasec(encoder, PERCPU_SECTION);
+
+ 	/* Empty file, nothing to do, so... done! */
+-	if (btf__get_nr_types(encoder->btf) == 0)
++	if (btf__type_cnt(encoder->btf) == 1)
+ 		return 0;
+
+-	if (btf__dedup(encoder->btf, NULL, NULL)) {
++	if (btf__dedup(encoder->btf, NULL)) {
+ 		fprintf(stderr, "%s: btf__dedup failed!\n", __func__);
+ 		return -1;
+ 	}
+@@ -1403,7 +1403,7 @@ void btf_encoder__delete(struct btf_encoder *encoder)
+
+ int btf_encoder__encode_cu(struct btf_encoder *encoder, struct cu *cu)
+ {
+-	uint32_t type_id_off = btf__get_nr_types(encoder->btf);
++	uint32_t type_id_off = btf__type_cnt(encoder->btf) - 1;
+ 	struct llvm_annotation *annot;
+ 	int btf_type_id, tag_type_id;
+ 	uint32_t core_id;
+diff --git a/btf_loader.c b/btf_loader.c
+index 7a5b16ff393e..c7d69ccea4d3 100644
+--- btf_loader.c
++++ btf_loader.c
+@@ -399,7 +399,7 @@ static int btf__load_types(struct btf *btf, struct cu *cu)
+ 	uint32_t type_index;
+ 	int err;
+
+-	for (type_index = 1; type_index <= btf__get_nr_types(btf); type_index++) {
++	for (type_index = 1; type_index < btf__type_cnt(btf); type_index++) {
+ 		const struct btf_type *type_ptr = btf__type_by_id(btf, type_index);
+ 		uint32_t type = btf_kind(type_ptr);
+
+--
+2.35.1

--- a/pahole/pkg.yaml
+++ b/pahole/pkg.yaml
@@ -1,0 +1,48 @@
+name: pahole
+dependencies:
+  - stage: argp-standalone
+  - stage: base
+  - stage: patch
+  - stage: elfutils
+  - stage: dwarfutils
+  - stage: cmake
+  - stage: curl
+  - stage: expat
+  - stage: libuv
+  - stage: musl-obstack
+  - stage: musl-fts
+  - stage: rhash
+  - stage: xz
+steps:
+  - sources:
+      - url: https://git.kernel.org/pub/scm/devel/pahole/pahole.git/snapshot/pahole-1.23.tar.gz
+        destination: pahole.tar.gz
+        sha256: 1cc78061a75ccd6894943e7e39398c191b9173e4830d12fe93a8ff61a3967036
+        sha512: e2f9da02c47bdf22fc0988be75168ba99eaa428b167153768e5e3457c510c7ac6e6f73d11e22b5b741b01fad46ebb74d5fff312f4112b03e9aac3b7b21553e3f
+      - url: https://github.com/libbpf/libbpf/archive/refs/tags/v0.8.0.tar.gz
+        destination: libbpf.tar.gz
+        sha256: f4480242651a93c101ece320030f6b2b9b437f622f807719c13cb32569a6d65a
+        sha512: 8b034a9c8f23207638630b95ff95a651148a800589eb52f2fe09698bf3c4147f2e2008b24de45a70832cc7669cdfebd78bc491e575ca0b27de5c2de3b1fb5637
+    prepare:
+      - |
+        tar -xzf pahole.tar.gz --strip-components=1
+        tar -C lib/bpf -xzf libbpf.tar.gz --strip-components=1
+
+        patch -Np0 -i /pkg/patches/libff-to-latest.patch
+    build:
+      - |
+        mkdir build && cd build
+
+        cmake -DCMAKE_INSTALL_PREFIX=${TOOLCHAIN} \
+              -DCMAKE_MODULE_PATH=/usr/lib/cmake \
+              -DCMAKE_INSTALL_RPATH=${TOOLCHAIN}/lib \
+              -D__LIB=lib \
+              ..
+    install:
+      - |
+        cd build
+        make DESTDIR=/rootfs install
+        rm -rf /rootfs/toolchain/share
+finalize:
+  - from: /rootfs
+    to: /

--- a/tools/pkg.yaml
+++ b/tools/pkg.yaml
@@ -18,6 +18,7 @@ dependencies:
   - stage: dejagnu
   - stage: diffutils
   - stage: dtc
+  - stage: dwarfutils
   - stage: elfutils
   - stage: expat
   - stage: expect
@@ -46,6 +47,7 @@ dependencies:
   - stage: musl-obstack
   - stage: ncurses
   - stage: openssl
+  - stage: pahole
   - stage: patch
   - stage: pcre
   - stage: perl


### PR DESCRIPTION
`pahole` is required so the kernel can be built with BTF support.

This commit builds upon the changes from
https://github.com/charlie-haley/tools/tree/feat/add-pahole

Additional changes done:

* Add missing -fPIC flag to argp-standalone
* Add missing dependencies to pahole
* Set TOOLCHAIN prefix for pahole

Signed-off-by: Robert Wunderer <robert.wunderer@caprisys.at>

Address review comments by @smira:

- Add source links to patches needed by pahole
- Refactor build of libdwarf to not rely on bldr internals.

Original PR #210, re-opened the PR get commit GPG signed.

Signed-off-by: Robert Wunderer <robert.wunderer@caprisys.at>
Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>