### PR TITLE
chore: bump toolchain

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -5,7 +5,7 @@
 format: v1alpha2
 
 vars:
-  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v0.6.0
+  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v0.6.0-1-g1f5b5e3
 
 labels:
   org.opencontainers.image.source: https://github.com/siderolabs/tools


### PR DESCRIPTION
Bump toolchain to use [gcc 12](https://github.com/siderolabs/toolchain/pull/36)

Signed-off-by: Noel Georgi <git@frezbo.dev>