### PR TITLE
chore: bump gcc to 12.2.0

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -5,7 +5,7 @@
 format: v1alpha2
 
 vars:
-  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v0.6.0-1-g1f5b5e3
+  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v0.6.0-2-gee7deca
 
 labels:
   org.opencontainers.image.source: https://github.com/siderolabs/tools


### PR DESCRIPTION
Bump gcc to [12.2.0](https://github.com/siderolabs/toolchain/pull/37)

Signed-off-by: Noel Georgi <git@frezbo.dev>