### PR TITLE
chore: bump go to 1.19.1

### DIFF
--- a/golang/golang/pkg.yaml
+++ b/golang/golang/pkg.yaml
@@ -4,10 +4,10 @@ dependencies:
   - stage: '{{ if eq .ARCH "aarch64" }}golang-alpine{{ else }}golang-bootstrap{{ end }}'
 steps:
   - sources:
-      - url: https://dl.google.com/go/go1.19.src.tar.gz
+      - url: https://dl.google.com/go/go1.19.1.src.tar.gz
         destination: go.src.tar.gz
-        sha256: 9419cc70dc5a2523f29a77053cafff658ed21ef3561d9b6b020280ebceab28b9
-        sha512: c4460d54957a0bcf3407ea72cd1c6b3c645ef4ef6cc0fa142a80cb43c06ca4af31d52b0ccd723c81d17a62004bc96559cad23da874a4b668b4d8b168f1da2186
+        sha256: 27871baa490f3401414ad793fba49086f6c855b1c584385ed7771e1204c7e179
+        sha512: 7e8cf557f05d5a537f9305bb9c19cf8ab9ce640376e5ea97ff0d490b016364936e8dfc129462760c4e817af01fdf09e3f815b88412f9985bb254dfa3167752c0
 
     env:
       GOROOT_BOOTSTRAP: '{{ .TOOLCHAIN }}/go_bootstrap'


### PR DESCRIPTION
Bump Golang to 1.19.1

Signed-off-by: Noel Georgi <git@frezbo.dev>