### PR TITLE
fix: revert gawk to 5.1.1

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -103,9 +103,9 @@ vars:
   flex_sha512: e9785f3d620a204b7d20222888917dc065c2036cae28667065bf7862dfa1b25235095a12fd04efdbd09bfd17d3452e6b9ef953a8c1137862ff671c97132a082e
 
   # renovate: datasource=git-tags extractVersion=^gawk-(?<version>.*)$ depName=git://git.savannah.gnu.org/gawk.git
-  gawk_version: 5.2.0
-  gawk_sha256: e4ddbad1c2ef10e8e815ca80208d0162d4c983e6cca16f925e8418632d639018
-  gawk_sha512: e81e1efb1be06f82602e704d10e8de4b78797d058d9718d353e0837660dc8adf952965240c0a3b1a71c3e295f2e9641eacf64496d1d896edd81b101e09a656ac
+  gawk_version: 5.1.1
+  gawk_sha256: d87629386e894bbea11a5e00515fc909dc9b7249529dad9e6a3a2c77085f7ea2
+  gawk_sha512: 794538fff03fdb9a8527a6898b26383d01988e8f8456f8d48131676387669a8bb3e706fa1a17f6b6316ddba0ebe653c24ad5dd769f357de509d6ec25f3ff1a43
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ versioning=loose depName=git://git.savannah.gnu.org/gettext.git
   gettext_version: 0.21


### PR DESCRIPTION
Rever gawk to last stable release, since kernel builds are broken with 5.2.0 gawk.

Ref: https://lists.gnu.org/archive/html/bug-gawk/2022-09/msg00025.html

Signed-off-by: Noel Georgi <git@frezbo.dev>