### PR TITLE
chore: bump toolchain and mpc versions

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -5,7 +5,7 @@
 format: v1alpha2
 
 vars:
-  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v0.7.0-2-gaa91e85
+  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v0.7.0-3-g45b5b5d
 
   # renovate: datasource=github-tags depName=argp-standalone/argp-standalone
   argp_standalone_version: 1.5.0
@@ -189,9 +189,9 @@ vars:
   meson_sha512: 4896f5a09f89cadce028080f70e5ca005fd3bb2141a730a0ad71ded63d1bde6d1254957fe079f5e4c6e3b9420a9fcc4525b01e689979f0bab6d09d6483ca42ec
 
   # renovate: datasource=git-tags depName=https://gitlab.inria.fr/mpc/mpc.git
-  mpc_version: 1.2.1
-  mpc_sha256: 17503d2c395dfcf106b622dc142683c1199431d095367c6aacba6eec30340459
-  mpc_sha512: 3279f813ab37f47fdcc800e4ac5f306417d07f539593ca715876e43e04896e1d5bceccfb288ef2908a3f24b760747d0dbd0392a24b9b341bc3e12082e5c836ee
+  mpc_version: 1.3.0
+  mpc_sha256: 0e3b12181d37207230f5a7a7ddcfc22abfc5fc9c05825e1a65401a489a432a2a
+  mpc_sha512: 9c18b24f7542dc1dc5e10cf58fd242e73d79a9dc3619c3f08d52aed75ad0e7d9e2ba2c46857717c8b921b084af2efc8c0d2d7173081af764b81c24a8971ddd9a
 
   # renovate: datasource=git-tags depName=https://gitlab.inria.fr/mpfr/mpfr.git
   mpfr_version: 4.1.1


### PR DESCRIPTION
This PR bumps toolchain to v0.7.0-3-g45b5b5d and mpc to 1.3.0. Renovate bot is also showing updates for golang, but it's an RC and not an actual release.

Finally, it's showing an update to protobuf, but their release process seems to not have published tar.gz files this time. I've added a thread to their forum to ask for clarity about this:

https://groups.google.com/g/protobuf/c/I4EXb4PhYyc

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>