### PR TITLE
chore: bump protobuf

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -245,9 +245,9 @@ vars:
   pkg_config_sha512: 4861ec6428fead416f5cbbbb0bbad10b9152967e481d4b0ff2eb396a9f297f552984c9bb72f6864a37dcd8fca1d9ccceda3ef18d8f121938dbe4fdf2b870fe75
 
   # renovate: datasource=github-tags extractVersion=^v(?<version>.*)$ depName=protocolbuffers/protobuf
-  protobuf_version: 3.21.10
-  protobuf_sha256: 7482ebfa862b1691cac2cb02ea1ffc56ff7f82c928dc876360f35579423c1465
-  protobuf_sha512: 3194c4789f58db429110323ee206404247848f4c45720b19074ba2de5240ad5c48f494add114e4d429dcf96081563db12cb7436be646f43b5d15f2b44bb1586e
+  protobuf_version: 3.21.11
+  protobuf_sha256: 96f0ab99b7414e44e7bf9b218bb59510d61549ca68e648f19e3622f9999bec00
+  protobuf_sha512: e945e0f364cff53bb56b89725c05bf11f7989a4ec9264972842dc62f086001d39b5de8ceab330e334af65fd3edbe3ffcc73cd959e27ef72485dd06be7b78c06b
 
   # renovate: datasource=github-releases depName=protocolbuffers/protobuf-go
   protoc_gen_go_version: v1.28.1


### PR DESCRIPTION
This PR bumps protobuf to 3.21.11

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>