### PR TITLE
feat: update Go to 1.20

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -124,9 +124,9 @@ vars:
   gmp_sha512: c99be0950a1d05a0297d65641dd35b75b74466f7bf03c9e8a99895a3b2f9a0856cd17887738fa51cf7499781b65c049769271cbcb77d057d2e9f1ec52e07dd84
 
   # renovate: datasource=github-tags extractVersion=^go(?<version>.*)$ depName=golang/go
-  golang_version: 1.19.5
-  golang_sha256: 8e486e8e85a281fc5ce3f0bedc5b9d2dbf6276d7db0b25d3ec034f313da0375f
-  golang_sha512: 26754f2a4870d0a5484162b626dad5109a33c116675898c84de46155659dadeff2b3fa9ea3dd0c7da8d23c8ff0974cfe42bdd07484e6f784617de3a577b3c883
+  golang_version: 1.20
+  golang_sha256: 3a29ff0421beaf6329292b8a46311c9fbf06c800077ceddef5fb7f8d5b1ace33
+  golang_sha512: 6b59af1094fafbf2dba6b26a5da0c6363d87b0997dd399cde40d9150e00bedd15100c0c8c12e31cfe7e153d2ea45b403764b2d83479d1cda74077179c8cca4d3
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ versioning=loose depName=git://git.savannah.gnu.org/gperf.git
   gperf_version: 3.1

--- a/golang/bootstrap/pkg.yaml
+++ b/golang/bootstrap/pkg.yaml
@@ -7,32 +7,49 @@ steps:
         destination: go1.4-bootstrap-20171003.tar.gz
         sha256: f4ff5b5eb3a3cae1c993723f3eab519c5bae18866b5e5f96fe1102f0cb5c3e52
         sha512: 2f65d5035d2b4ae8610c3337e0fcba64692c63953b54bf735f634da3532c6573ed08927865bf068b00a3885663815c5efc7dbd9a1b3d6337c9a0c62168aabca7
-
+      - url: https://dl.google.com/go/go1.17.13.src.tar.gz
+        destination: go1.17.13.tar.gz
+        sha256: a1a48b23afb206f95e7bbaa9b898d965f90826f6f1d1fc0c1d784ada0cd300fd
+        sha512: 2820bdd679fdb5e37d4c601b26c246bab23d4e8e1b226ac37c38e90a68b693e877bff944275eb25e3296ee772e7b40ef7d71dd49cca524df4cb8e721bfb50c33
     env:
+      GOROOT_INTERMEDIATE: '{{ .TOOLCHAIN }}/go_intermediate'
       GOROOT_FINAL: '{{ .TOOLCHAIN }}/go_bootstrap'
 
     prepare:
-      - tar -xzf go1.4-bootstrap-20171003.tar.gz --strip-components=1
+      - |
+        mkdir go1.4-bootstrap-20171003
+        tar -xzf go1.4-bootstrap-20171003.tar.gz --strip-components=1 -C go1.4-bootstrap-20171003
+      - |
+        mkdir go1.17.13
+        tar xzf go1.17.13.tar.gz --strip-components=1 -C go1.17.13
 
     build:
-      - cd src && sh make.bash
-
+      - |
+        cd go1.4-bootstrap-20171003
+        cd src && sh make.bash
+      - |
+        cd go1.4-bootstrap-20171003
+        rm -rf pkg/obj
+        rm -rf pkg/bootstrap
+        find src \( -type f -a -name "*_test.go" \) -exec rm -rf \{\} \+
+        find src \( -type d -a -name "testdata" \) -exec rm -rf \{\} \+
+        find src -type f -a \( -name "*.bash" -o -name "*.rc" -o -name "*.bat" \) -exec rm -rf \{\} \+
+        mkdir -p "/rootfs${GOROOT_INTERMEDIATE}"
+        mv * "/rootfs${GOROOT_INTERMEDIATE}"
+      - |
+        export GOROOT_BOOTSTRAP="/rootfs{{ .TOOLCHAIN }}/go_intermediate"
+        cd go1.17.13
+        cd src && sh make.bash
     install:
-      - rm -rf pkg/obj
-      - rm -rf pkg/bootstrap
-      - rm -f pkg/tool/*/api
       - |
-        find src \( -type f -a -name "*_test.go" \) \
-        -exec rm -rf \{\} \+
-      - |
-        find src \( -type d -a -name "testdata" \) \
-        -exec rm -rf \{\} \+
-      - |
-        find src -type f -a \( -name "*.bash" -o -name "*.rc" -o -name "*.bat" \) \
-        -exec rm -rf \{\} \+
-
-      - mkdir -p "/rootfs${GOROOT_FINAL}"
-      - mv * "/rootfs${GOROOT_FINAL}"
+        cd go1.17.13
+        rm -rf pkg/obj
+        rm -f pkg/tool/*/api
+        find src \( -type f -a -name "*_test.go" \) -exec rm -rf \{\} \+
+        find src \( -type d -a -name "testdata" \) -exec rm -rf \{\} \+
+        find src -type f -a \( -name "*.bash" -o -name "*.rc" -o -name "*.bat" \) -exec rm -rf \{\} \+
+        mkdir -p "/rootfs${GOROOT_FINAL}"
+        mv * "/rootfs${GOROOT_FINAL}"
 
 finalize:
   - from: /rootfs


### PR DESCRIPTION
Go 1.20 requires Go 1.17.13 for bootstrapping, so the built process is as follows:

Go 1.4 -> Go 1.17.13 -> Go 1.20

Ref: https://go.dev/doc/go1.20#bootstrap

Signed-off-by: Noel Georgi <git@frezbo.dev>