### PR TITLE
chore: bump go to 1.20.1

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -124,9 +124,9 @@ vars:
   gmp_sha512: c99be0950a1d05a0297d65641dd35b75b74466f7bf03c9e8a99895a3b2f9a0856cd17887738fa51cf7499781b65c049769271cbcb77d057d2e9f1ec52e07dd84
 
   # renovate: datasource=github-tags extractVersion=^go(?<version>.*)$ depName=golang/go
-  golang_version: 1.20
-  golang_sha256: 3a29ff0421beaf6329292b8a46311c9fbf06c800077ceddef5fb7f8d5b1ace33
-  golang_sha512: 6b59af1094fafbf2dba6b26a5da0c6363d87b0997dd399cde40d9150e00bedd15100c0c8c12e31cfe7e153d2ea45b403764b2d83479d1cda74077179c8cca4d3
+  golang_version: 1.20.1
+  golang_sha256: b5c1a3af52c385a6d1c76aed5361cf26459023980d0320de7658bae3915831a2
+  golang_sha512: 57453419fafac8af10f4037b0162326555aab0e87cd1d246d5e977246c075a0504c23022d5c14bfcae9ca1c3250652ddd7c6fcf2209a926525e5f7d0d40ab52d
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ versioning=loose depName=git://git.savannah.gnu.org/gperf.git
   gperf_version: 3.1


### PR DESCRIPTION
Bump Golang to 1.20.1

Ref: https://groups.google.com/g/golang-announce/c/V0aBFqaFs_E/m/CnYKgKwBBQAJ