### PR TITLE
chore: bump go to 1.20.4

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -129,9 +129,9 @@ vars:
   gmp_sha512: c99be0950a1d05a0297d65641dd35b75b74466f7bf03c9e8a99895a3b2f9a0856cd17887738fa51cf7499781b65c049769271cbcb77d057d2e9f1ec52e07dd84
 
   # renovate: datasource=github-tags extractVersion=^go(?<version>.*)$ depName=golang/go
-  golang_version: 1.20.3
-  golang_sha256: e447b498cde50215c4f7619e5124b0fc4e25fb5d16ea47271c47f278e7aa763a
-  golang_sha512: 47ebb3925956a3facef9e5e6f4efec3058e55632020ea247844c55b160d23e2be3880ea24dec2f73382a7c7858259896cbb7de1bb764c481c176bed479676029
+  golang_version: 1.20.4
+  golang_sha256: 9f34ace128764b7a3a4b238b805856cc1b2184304df9e5690825b0710f4202d6
+  golang_sha512: 43898325bab48c24e533f360a2c7de356a8a56946602e727b5bcd4a62ff4f64fd750e2650032f7e0525b0699e40e506d79446e16838f097e6bdc2a16f10d81be
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.savannah.gnu.org/gperf.git
   gperf_version: 3.1


### PR DESCRIPTION
Bump Golang to 1.20.4.

Signed-off-by: Noel Georgi <git@frezbo.dev>
(cherry picked from commit 47b0fd3e364d4fbcfffe10965f740db7acd82f70)