### PR TITLE
feat: add libcap and gnuefi

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -53,7 +53,8 @@
                 "git://git.savannah.gnu.org/patch.git",
                 "https://gitlab.freedesktop.org/pkg-config/pkg-config.git",
                 "git://git.savannah.gnu.org/sed.git",
-                "git://git.savannah.gnu.org/texinfo.git"
+                "git://git.savannah.gnu.org/texinfo.git",
+                "git://git.kernel.org/pub/scm/libs/libcap/libcap.git"
             ],
             "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.?(?<patch>\\d+)?$"
         },

--- a/Pkgfile
+++ b/Pkgfile
@@ -143,6 +143,12 @@ vars:
   grep_sha256: 24efa5b595fb5a7100879b51b8868a0bb87a71c183d02c4c602633b88af6855b
   grep_sha512: 865e8f3fd7afc68f1a52f5e1e1ee05fb9c6d6182201efb0dbdf6075347b0b1d2bf0784537a8f8dd4fb050d523f7a1d2fb5b9c3e3245087d0e6cc12d6e9d3961b
 
+  # renovate: datasource=git-tags depName=https://git.code.sf.net/p/gnu-efi/code.git
+  # we have to use 3.0.15 for now, since anything later breaks building sd-stub/sd-boot.
+  gnuefi_version: 3.0.15
+  gnuefi_sha256: 931a257b9c5c1ba65ff519f18373c438a26825f2db7866b163e96d1b168f20ea
+  gnuefi_sha512: 64d408b6d115bdc6eebae12fbd6cd907ed5f847f54e506c1e8f8ea5de38a95cf6fac66ab1009bd1d0bd2d54ad45ad598d29bcc303926a5899bf5cc25448cbb2f
+
   # renovate: datasource=git-tags depName=https://gitlab.com/gnutls/gnutls.git
   gnutls_version: 3.8.0
   gnutls_sha256: 0ea0d11a1660a1e63f960f157b197abe6d0c8cb3255be24e1fb3815930b9bdc5
@@ -162,6 +168,11 @@ vars:
   libbpf_version: v1.1.0
   libbpf_sha256: 5da826c968fdb8a2f714701cfef7a4b7078be030cf58b56143b245816301cbb8
   libbpf_sha512: 751126893883c68e5472724988327e03f7f52becd472f7d6239fa838762f857e54a0347f8f824b8c32ca93b8f419310a86e1d75e3646dae72c2d2992d093b828
+
+  # renovate: datasource=git-tags extractVersion=^libcap-(?<version>.*)$ depName=git://git.kernel.org/pub/scm/libs/libcap/libcap.git
+  libcap_version: 2.68
+  libcap_sha256: 90be3b6d41be5f81ae4b03ec76012b0d27c829293684f6c05b65d5f9cce724b2
+  libcap_sha512: ede3e1356aef22e18a46dc8ff0727500ab023bea698cf2bb822abb06625e272940afea52ad6457d0cd8cf1c7f435f1b568baf0a6bf0a08ae96fbf6d7502f9de2
 
   # renovate: datasource=github-tags extractVersion=^v(?<version>.*)$ depName=libffi/libffi
   libffi_version: 3.4.4

--- a/gnuefi/patches/no-werror.patch
+++ b/gnuefi/patches/no-werror.patch
@@ -1,0 +1,15 @@
+# https://git.alpinelinux.org/aports/tree/main/gnu-efi/no-werror.patch
+diff --git a/Make.defaults b/Make.defaults
+index ba743f1..5fd1b66 100755
+--- a/Make.defaults
++++ b/Make.defaults
+@@ -170,7 +170,7 @@ CFLAGS  += $(ARCH3264) -g -O2 -Wall -Wextra -Werror \
+            -fshort-wchar -fno-strict-aliasing \
+            -ffreestanding -fno-stack-protector
+ else
+-CFLAGS  += $(ARCH3264) -g -O2 -Wall -Wextra -Werror \
++CFLAGS  += $(ARCH3264) -g -O2 -Wall -Wextra \
+            -fshort-wchar -fno-strict-aliasing \
+ 	   -ffreestanding -fno-stack-protector -fno-stack-check \
+            -fno-stack-check \
+

--- a/gnuefi/pkg.yaml
+++ b/gnuefi/pkg.yaml
@@ -1,0 +1,31 @@
+name: gnuefi
+dependencies:
+  - stage: base
+  - stage: patch
+    runtime: true
+steps:
+  - sources:
+      - url: https://src.fedoraproject.org/lookaside/extras/gnu-efi/gnu-efi-{{ .gnuefi_version }}.tar.bz2/sha512/64d408b6d115bdc6eebae12fbd6cd907ed5f847f54e506c1e8f8ea5de38a95cf6fac66ab1009bd1d0bd2d54ad45ad598d29bcc303926a5899bf5cc25448cbb2f/gnu-efi-{{ .gnuefi_version }}.tar.bz2
+        destination: gnuefi.tar.bz2
+        sha256: "{{ .gnuefi_sha256 }}"
+        sha512: "{{ .gnuefi_sha512 }}"
+    prepare:
+      - |
+        tar -xf gnuefi.tar.bz2 --strip-components=1
+
+        patch -p1 < /pkg/patches/no-werror.patch
+    build:
+      - |
+        make -j $(nproc) -C lib
+        make -j $(nproc) -C gnuefi
+        make -j $(nproc) -C inc
+    install:
+      - |
+        mkdir -p /rootfs
+
+        make -j $(nproc ) -C lib PREFIX=${TOOLCHAIN} INSTALLROOT=/rootfs install
+        make -j $(nproc ) -C gnuefi PREFIX=${TOOLCHAIN} INSTALLROOT=/rootfs install
+        make -j $(nproc ) -C inc PREFIX=${TOOLCHAIN} INSTALLROOT=/rootfs install
+finalize:
+  - from: /rootfs
+    to: /

--- a/libcap2/pkg.yaml
+++ b/libcap2/pkg.yaml
@@ -1,0 +1,22 @@
+name: libcap
+dependencies:
+  - stage: base
+steps:
+  - sources:
+      - url: https://kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-{{ .libcap_version }}.tar.xz
+        destination: libcap.tar.xz
+        sha256: "{{ .libcap_sha256 }}"
+        sha512: "{{ .libcap_sha512 }}"
+    prepare:
+      - |
+        tar -xf libcap.tar.xz --strip-components=1
+    build:
+      - |
+        make prefix=${TOOLCHAIN} lib=lib -j $(nproc)
+    install:
+      - |
+        make DESTDIR=/rootfs prefix=${TOOLCHAIN} lib=lib install
+        rm -rf /rootfs/${TOOLCHAIN}/share
+finalize:
+  - from: /rootfs
+    to: /

--- a/tools/pkg.yaml
+++ b/tools/pkg.yaml
@@ -33,6 +33,7 @@ dependencies:
   - stage: golang
   - stage: gperf
   - stage: grep
+  - stage: gnuefi
   - stage: gnutls
   - stage: gzip
   - stage: kmod
@@ -40,6 +41,7 @@ dependencies:
   - stage: libffi
   - stage: libnl
   - stage: libtool
+  - stage: libcap
   - stage: libuv
   - stage: libtasn1
   - stage: libunistring


### PR DESCRIPTION
Add libcap and gnu-efi. This is required for building `sd-stub` and `sd-boot`.