### PR TITLE
feat: add sd-tools

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -66,7 +66,8 @@
         },
         {
             "matchPackageNames": [
-                "git://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git"
+                "git://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git",
+                "systemd/systemd"
             ],
             "versioning": "regex:^(?<major>\\d+)\\.?(?<minor>\\d+)?\\.?(?<patch>\\d+)?$"
         },
@@ -104,6 +105,12 @@
                 "Perl/perl5"
             ],
             "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d[02468]+)\\.(?<patch>\\d+)$"
+        },
+        {
+            "matchPackageNames": [
+                "json-c/json-c"
+            ],
+            "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.?(?<patch>\\d+)?\\.?(?<build>\\d+)?$"
         },
         {
             "matchPackagePatterns": [

--- a/Pkgfile
+++ b/Pkgfile
@@ -179,6 +179,11 @@ vars:
   libffi_sha256: d66c56ad259a82cf2a9dfc408b32bf5da52371500b84745f7fb8b645712df676
   libffi_sha512: 88680aeb0fa0dc0319e5cd2ba45b4b5a340bc9b4bcf20b1e0613b39cd898f177a3863aa94034d8e23a7f6f44d858a53dcd36d1bb8dee13b751ef814224061889
 
+  # renovate: datasource=github-tags extractVersion=^json-c-(?<version>.*)-.*$ depName=json-c/json-c
+  libjson_c_version: 0.16
+  libjson_c_sha256: 8e45ac8f96ec7791eaf3bb7ee50e9c2100bbbc87b8d0f1d030c5ba8a0288d96b
+  libjson_c_sha512: 255cff99033340b2c2678255d41dae7808f83ed0c102e693d2d9e186bd1f21dd1385fcaa360c0fc087a00965a9567fbda733370e6b518a9be2f1bb0a80439151
+
   # renovate datasource=github-releases extractVersion=^libnl(?<version>.*)$ depName=thom311/libnl
   libnl_version: 3_7_0
   libnl_sha256: 9fe43ccbeeea72c653bdcf8c93332583135cda46a79507bfd0a483bb57f65939
@@ -325,6 +330,11 @@ vars:
   swig_sha256: 2af08aced8fcd65cdb5cc62426768914bedc735b1c250325203716f78e39ac9b
   swig_sha512: 1cea1918455a75ebc9b2653dd1715bd5dcd974554955f324295c6a6f14c0a715651b221b85fad4a8af5197e0c75bfe7b590bc6ba7178c26245fbbd9a7e110100
 
+  # renovate: datasource=github-releases depName=systemd/systemd
+  systemd_version: 253
+  systemd_sha256: acbd86d42ebc2b443722cb469ad215a140f504689c7a9133ecf91b235275a491
+  systemd_sha512: 3bbc431a292ab590b70d3b490a528f71d30ccf478ddfa66d1c210f40c260ef49ac30651c19f2d073acf38d68398a4a6fbf95391f0e3ea0333d94b9d4e81d514f
+
   # renovate: datasource=git-tags extractVersion=^release_(?<version>.*)$ depName=git://git.savannah.gnu.org/tar.git
   tar_version: 1_34
   tar_sha256: 63bebd26879c5e1eea4352f0d03c991f966aeb3ddeb3c7445c902568d5411d28
@@ -339,6 +349,11 @@ vars:
   texinfo_version: 7.0.3
   texinfo_sha256: 74b420d09d7f528e84f97aa330f0dd69a98a6053e7a4e01767eed115038807bf
   texinfo_sha512: 7d14f7458f2b7d0ee0b740e00a5fc2a9d61d33811aa5905d649875ec518dcb4f01be46fb0c46748f7dfe36950597a852f1473ab0648d5add225bc8f35528a8ff
+
+  # renovate: datasource=github-tags depName=tpm2-software/tpm2-tss
+  tpm2_tss_version: 4.0.1
+  tpm2_tss_sha256: 532a70133910b6bd842289915b3f9423c0205c0ea009d65294ca18a74087c950
+  tpm2_tss_sha512: ed6ddc52cb0e8c1082a4bb001e1225eb9905fd2380da88db5fd69ff5b5d9d43a93eb67b634e49d53eb5d586832da3aef2c4c7e5f18d51bb730481f8913319d7d
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/utils/util-linux/util-linux.git
   util_linux_version: 2.38.1

--- a/libjson-c/pkg.yaml
+++ b/libjson-c/pkg.yaml
@@ -1,0 +1,36 @@
+name: libjson-c
+dependencies:
+  - stage: base
+  - stage: cmake
+    runtime: true
+  - stage: curl
+  - stage: libuv
+  - stage: xz
+  - stage: rhash
+  - stage: expat
+steps:
+  - sources:
+      - url: https://s3.amazonaws.com/json-c_releases/releases/json-c-{{ .libjson_c_version }}.tar.gz
+        destination: json-c.tar.gz
+        sha256: "{{ .libjson_c_sha256 }}"
+        sha512: "{{ .libjson_c_sha512 }}"
+    prepare:
+      - |
+        tar -xzf json-c.tar.gz --strip-components=1
+
+        cmake -B build \
+          -DCMAKE_INSTALL_PREFIX=${TOOLCHAIN} \
+          -DCMAKE_INSTALL_LIBDIR=lib \
+          -DBUILD_SHARED_LIBS=True \
+          -DBUILD_STATIC_LIBS=True \
+          -DCMAKE_BUILD_TYPE=None \
+         .
+    build:
+      - |
+        make -C build -j $(nproc)
+    install:
+      - |
+        make -C build DESTDIR=/rootfs install
+finalize:
+  - from: /rootfs
+    to: /

--- a/sd-boot/patches/musl.patch
+++ b/sd-boot/patches/musl.patch
@@ -1,0 +1,40 @@
+From a4ff7772acf1d983921833aa20ccd7c4d5e59a1c Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex@linutronix.de>
+Date: Mon, 6 Mar 2023 15:24:49 +0100
+Subject: [PATCH] src/boot/efi/efi-string.c: define wchar_t from __WCHAR_TYPE__
+
+systemd-boot relies on wchar_t being 16 bit, and breaks at build time otherwise.
+
+To set wchar_t to 16 bit it is passing -fshort-wchar to gcc; this has the
+desired effect on glibc (which sets wchar_t from __WCHAR_TYPE__) but not on
+musl (which hardcodes it to 32 bit).
+
+This patch ensures wchar_t is set from the compiler flags on all systems; note
+that systemd-boot is not actually using functions from musl or other libc, just their headers.
+
+Meanwhile upstream has refactored the code to not rely on libc headers at all;
+however this will not be backported to v253 and we need a different fix.
+
+Upstream-Status: Inappropriate [fixed differently in trunk according to https://github.com/systemd/systemd/pull/26689]
+Signed-off-by: Alexander Kanavin <alex@linutronix.de>
+---
+ src/boot/efi/efi-string.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/boot/efi/efi-string.c b/src/boot/efi/efi-string.c
+index 22923d60f6..22a8d1ef71 100644
+--- a/src/boot/efi/efi-string.c
++++ b/src/boot/efi/efi-string.c
+@@ -2,7 +2,13 @@
+
+ #include <stdbool.h>
+ #include <stdint.h>
++
++#if SD_BOOT
++typedef __WCHAR_TYPE__ wchar_t;
++#define __DEFINED_wchar_t
++#else
+ #include <wchar.h>
++#endif
+
+ #include "efi-string.h"

--- a/sd-boot/pkg.yaml
+++ b/sd-boot/pkg.yaml
@@ -1,0 +1,62 @@
+name: sd-boot
+dependencies:
+  - stage: base
+  - stage: coreutils
+  - stage: gnuefi
+  - stage: gperf
+  - stage: libcap
+  - stage: meson
+    runtime: true
+  - stage: openssl
+  - stage: patch
+    runtime: true
+  - stage: pkg-config
+    runtime: true
+  - stage: python3
+  - stage: tpm2-tss
+  - stage: util-linux
+steps:
+  - sources:
+      - url: https://github.com/systemd/systemd/archive/refs/tags/v{{ .systemd_version }}.tar.gz
+        destination: systemd.tar.gz
+        sha256: "{{ .systemd_sha256 }}"
+        sha512: "{{ .systemd_sha512 }}"
+    env:
+      LD_LIBRARY_PATH: "/toolchain/lib"
+    prepare:
+      - |
+        tar -xzf systemd.tar.gz --strip-components=1
+
+        ln -s /toolchain/bin/echo /toolchain/bin/getent
+        mkdir -p /usr/bin
+        ln -sf /toolchain/bin/env /usr/bin/env
+        ln -sf /toolchain/bin/python3 /toolchain/bin/python
+
+        pip3 install jinja2 ninja
+
+        patch -p1 < /pkg/patches/musl.patch
+
+        meson setup build \
+          --buildtype=release \
+          -Dmode=release \
+          -Dsbat-distro=talos \
+          -Dsbat-distro-summary="Talos Linux" \
+          -Dsbat-distro-url=https://github.com/siderolabs/tools/issues \
+          -Dman=false \
+          -Defi=true \
+          -Dgnu-efi=true \
+          -Defi-libdir=/toolchain/lib \
+          -Defi-includedir=/toolchain/include/efi \
+          -Dtpm2=true \
+          -Dtests=false
+    build:
+      - |
+        ninja -j $(nproc) -C build systemd-boot
+    install:
+      - |
+        mkdir -p /rootfs/toolchain/lib/systemd/boot/efi
+
+        cp build/src/boot/efi/*.efi /rootfs/toolchain/lib/systemd/boot/efi
+finalize:
+  - from: /rootfs
+    to: /

--- a/sd-measure/patches/0001-Adjust-for-musl-headers.patch
+++ b/sd-measure/patches/0001-Adjust-for-musl-headers.patch
@@ -1,0 +1,555 @@
+From e5f067cb3dc845dd865e450f4e64077b28feb4c0 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 21 Jan 2022 22:19:37 -0800
+Subject: [PATCH] Adjust for musl headers
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/libsystemd-network/sd-dhcp6-client.c      | 2 +-
+ src/network/netdev/bareudp.c                  | 2 +-
+ src/network/netdev/batadv.c                   | 2 +-
+ src/network/netdev/bond.c                     | 2 +-
+ src/network/netdev/bridge.c                   | 2 +-
+ src/network/netdev/dummy.c                    | 2 +-
+ src/network/netdev/geneve.c                   | 2 +-
+ src/network/netdev/ifb.c                      | 2 +-
+ src/network/netdev/ipoib.c                    | 2 +-
+ src/network/netdev/ipvlan.c                   | 2 +-
+ src/network/netdev/macsec.c                   | 2 +-
+ src/network/netdev/macvlan.c                  | 2 +-
+ src/network/netdev/netdev.c                   | 2 +-
+ src/network/netdev/netdevsim.c                | 2 +-
+ src/network/netdev/nlmon.c                    | 2 +-
+ src/network/netdev/tunnel.c                   | 2 +-
+ src/network/netdev/vcan.c                     | 2 +-
+ src/network/netdev/veth.c                     | 2 +-
+ src/network/netdev/vlan.c                     | 2 +-
+ src/network/netdev/vrf.c                      | 2 +-
+ src/network/netdev/vxcan.c                    | 2 +-
+ src/network/netdev/vxlan.c                    | 2 +-
+ src/network/netdev/wireguard.c                | 2 +-
+ src/network/netdev/xfrm.c                     | 2 +-
+ src/network/networkd-bridge-mdb.c             | 4 ++--
+ src/network/networkd-dhcp-common.c            | 3 ++-
+ src/network/networkd-dhcp-prefix-delegation.c | 4 ++--
+ src/network/networkd-dhcp-server.c            | 2 +-
+ src/network/networkd-dhcp4.c                  | 2 +-
+ src/network/networkd-ipv6ll.c                 | 2 +-
+ src/network/networkd-link.c                   | 2 +-
+ src/network/networkd-ndisc.c                  | 2 +-
+ src/network/networkd-route.c                  | 8 ++++----
+ src/network/networkd-setlink.c                | 2 +-
+ src/shared/linux/ethtool.h                    | 3 ++-
+ src/shared/netif-util.c                       | 2 +-
+ src/udev/udev-builtin-net_id.c                | 2 +-
+ 37 files changed, 44 insertions(+), 42 deletions(-)
+
+diff --git a/src/libsystemd-network/sd-dhcp6-client.c b/src/libsystemd-network/sd-dhcp6-client.c
+index 57dd91f81f..2b7f4fa3a7 100644
+--- a/src/libsystemd-network/sd-dhcp6-client.c
++++ b/src/libsystemd-network/sd-dhcp6-client.c
+@@ -5,7 +5,7 @@
+
+ #include <errno.h>
+ #include <sys/ioctl.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/if_infiniband.h>
+
+ #include "sd-dhcp6-client.h"
+diff --git a/src/network/netdev/bareudp.c b/src/network/netdev/bareudp.c
+index 24d3afb877..f6241b41ee 100644
+--- a/src/network/netdev/bareudp.c
++++ b/src/network/netdev/bareudp.c
+@@ -2,7 +2,7 @@
+  * Copyright © 2020 VMware, Inc. */
+
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+
+ #include "bareudp.h"
+ #include "netlink-util.h"
+diff --git a/src/network/netdev/batadv.c b/src/network/netdev/batadv.c
+index 7e97619657..50fcffcfdf 100644
+--- a/src/network/netdev/batadv.c
++++ b/src/network/netdev/batadv.c
+@@ -3,7 +3,7 @@
+ #include <inttypes.h>
+ #include <netinet/in.h>
+ #include <linux/genetlink.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+
+ #include "batadv.h"
+ #include "fileio.h"
+diff --git a/src/network/netdev/bond.c b/src/network/netdev/bond.c
+index 601bff0a9c..dfed8d9e54 100644
+--- a/src/network/netdev/bond.c
++++ b/src/network/netdev/bond.c
+@@ -1,7 +1,7 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+
+ #include "alloc-util.h"
+ #include "bond.h"
+diff --git a/src/network/netdev/bridge.c b/src/network/netdev/bridge.c
+index b65c3b49fc..6875b4fbdb 100644
+--- a/src/network/netdev/bridge.c
++++ b/src/network/netdev/bridge.c
+@@ -2,7 +2,7 @@
+
+ #include <net/if.h>
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/if_bridge.h>
+
+ #include "bridge.h"
+diff --git a/src/network/netdev/dummy.c b/src/network/netdev/dummy.c
+index 00df1d2787..77b506b422 100644
+--- a/src/network/netdev/dummy.c
++++ b/src/network/netdev/dummy.c
+@@ -1,6 +1,6 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+
+ #include "dummy.h"
+
+diff --git a/src/network/netdev/geneve.c b/src/network/netdev/geneve.c
+index 777a32d75c..73bfa2b5c1 100644
+--- a/src/network/netdev/geneve.c
++++ b/src/network/netdev/geneve.c
+@@ -2,7 +2,7 @@
+
+ #include <net/if.h>
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+
+ #include "alloc-util.h"
+ #include "conf-parser.h"
+diff --git a/src/network/netdev/ifb.c b/src/network/netdev/ifb.c
+index d7ff44cb9e..e037629ae4 100644
+--- a/src/network/netdev/ifb.c
++++ b/src/network/netdev/ifb.c
+@@ -1,7 +1,7 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later
+  * Copyright © 2019 VMware, Inc. */
+
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+
+ #include "ifb.h"
+
+diff --git a/src/network/netdev/ipoib.c b/src/network/netdev/ipoib.c
+index 5dd9286d57..4036d66dad 100644
+--- a/src/network/netdev/ipoib.c
++++ b/src/network/netdev/ipoib.c
+@@ -1,6 +1,6 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/if_link.h>
+
+ #include "ipoib.h"
+diff --git a/src/network/netdev/ipvlan.c b/src/network/netdev/ipvlan.c
+index 058eadebd7..c470ebb6d7 100644
+--- a/src/network/netdev/ipvlan.c
++++ b/src/network/netdev/ipvlan.c
+@@ -2,7 +2,7 @@
+
+ #include <net/if.h>
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+
+ #include "conf-parser.h"
+ #include "ipvlan.h"
+diff --git a/src/network/netdev/macsec.c b/src/network/netdev/macsec.c
+index 0da3dd4bd2..eb20f04469 100644
+--- a/src/network/netdev/macsec.c
++++ b/src/network/netdev/macsec.c
+@@ -1,7 +1,7 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/if_ether.h>
+ #include <linux/if_macsec.h>
+ #include <linux/genetlink.h>
+diff --git a/src/network/netdev/macvlan.c b/src/network/netdev/macvlan.c
+index 1114bb0cb1..6c79a219a4 100644
+--- a/src/network/netdev/macvlan.c
++++ b/src/network/netdev/macvlan.c
+@@ -2,7 +2,7 @@
+
+ #include <net/if.h>
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+
+ #include "conf-parser.h"
+ #include "macvlan.h"
+diff --git a/src/network/netdev/netdev.c b/src/network/netdev/netdev.c
+index 038a27c118..67155f0db7 100644
+--- a/src/network/netdev/netdev.c
++++ b/src/network/netdev/netdev.c
+@@ -2,7 +2,7 @@
+
+ #include <net/if.h>
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <unistd.h>
+
+ #include "alloc-util.h"
+diff --git a/src/network/netdev/netdevsim.c b/src/network/netdev/netdevsim.c
+index 15d5c132f9..a3ffa48b15 100644
+--- a/src/network/netdev/netdevsim.c
++++ b/src/network/netdev/netdevsim.c
+@@ -1,6 +1,6 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+
+ #include "netdevsim.h"
+
+diff --git a/src/network/netdev/nlmon.c b/src/network/netdev/nlmon.c
+index ff372092e6..eef66811f4 100644
+--- a/src/network/netdev/nlmon.c
++++ b/src/network/netdev/nlmon.c
+@@ -1,6 +1,6 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+
+ #include "nlmon.h"
+
+diff --git a/src/network/netdev/tunnel.c b/src/network/netdev/tunnel.c
+index 2addfeecaa..954987f26d 100644
+--- a/src/network/netdev/tunnel.c
++++ b/src/network/netdev/tunnel.c
+@@ -2,7 +2,7 @@
+
+ #include <netinet/in.h>
+ #include <linux/fou.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/if_tunnel.h>
+ #include <linux/ip.h>
+ #include <linux/ip6_tunnel.h>
+diff --git a/src/network/netdev/vcan.c b/src/network/netdev/vcan.c
+index 380547ee1e..137c1adf8a 100644
+--- a/src/network/netdev/vcan.c
++++ b/src/network/netdev/vcan.c
+@@ -1,6 +1,6 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+
+ #include "vcan.h"
+
+diff --git a/src/network/netdev/veth.c b/src/network/netdev/veth.c
+index fb00e6667f..f52d9ee89a 100644
+--- a/src/network/netdev/veth.c
++++ b/src/network/netdev/veth.c
+@@ -3,7 +3,7 @@
+ #include <errno.h>
+ #include <net/if.h>
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/veth.h>
+
+ #include "netlink-util.h"
+diff --git a/src/network/netdev/vlan.c b/src/network/netdev/vlan.c
+index a3d961dac3..386b567a42 100644
+--- a/src/network/netdev/vlan.c
++++ b/src/network/netdev/vlan.c
+@@ -2,7 +2,7 @@
+
+ #include <errno.h>
+ #include <net/if.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/if_vlan.h>
+
+ #include "parse-util.h"
+diff --git a/src/network/netdev/vrf.c b/src/network/netdev/vrf.c
+index 05ef3ff13d..825fc4a398 100644
+--- a/src/network/netdev/vrf.c
++++ b/src/network/netdev/vrf.c
+@@ -2,7 +2,7 @@
+
+ #include <net/if.h>
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+
+ #include "vrf.h"
+
+diff --git a/src/network/netdev/vxcan.c b/src/network/netdev/vxcan.c
+index 83269b0707..39c6dbe29c 100644
+--- a/src/network/netdev/vxcan.c
++++ b/src/network/netdev/vxcan.c
+@@ -1,7 +1,7 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+ #include <linux/can/vxcan.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+
+ #include "vxcan.h"
+
+diff --git a/src/network/netdev/vxlan.c b/src/network/netdev/vxlan.c
+index 589161938a..0ec9625b7a 100644
+--- a/src/network/netdev/vxlan.c
++++ b/src/network/netdev/vxlan.c
+@@ -2,7 +2,7 @@
+
+ #include <net/if.h>
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+
+ #include "conf-parser.h"
+ #include "alloc-util.h"
+diff --git a/src/network/netdev/wireguard.c b/src/network/netdev/wireguard.c
+index 51e7e02990..fc36c0623a 100644
+--- a/src/network/netdev/wireguard.c
++++ b/src/network/netdev/wireguard.c
+@@ -6,7 +6,7 @@
+ #include <sys/ioctl.h>
+ #include <net/if.h>
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/ipv6_route.h>
+
+ #include "sd-resolve.h"
+diff --git a/src/network/netdev/xfrm.c b/src/network/netdev/xfrm.c
+index a961d8fef2..6c1815b257 100644
+--- a/src/network/netdev/xfrm.c
++++ b/src/network/netdev/xfrm.c
+@@ -1,6 +1,6 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+
+ #include "missing_network.h"
+ #include "xfrm.h"
+diff --git a/src/network/networkd-bridge-mdb.c b/src/network/networkd-bridge-mdb.c
+index bd1a9745dc..949d3da029 100644
+--- a/src/network/networkd-bridge-mdb.c
++++ b/src/network/networkd-bridge-mdb.c
+@@ -1,7 +1,5 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+-#include <net/if.h>
+-#include <linux/if_bridge.h>
+
+ #include "netlink-util.h"
+ #include "networkd-bridge-mdb.h"
+@@ -11,6 +9,8 @@
+ #include "networkd-queue.h"
+ #include "string-util.h"
+ #include "vlan-util.h"
++#include <net/if.h>
++#include <linux/if_bridge.h>
+
+ #define STATIC_BRIDGE_MDB_ENTRIES_PER_NETWORK_MAX 1024U
+
+diff --git a/src/network/networkd-dhcp-common.c b/src/network/networkd-dhcp-common.c
+index ca9a825e7b..8735e261ad 100644
+--- a/src/network/networkd-dhcp-common.c
++++ b/src/network/networkd-dhcp-common.c
+@@ -1,7 +1,8 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
++#include <net/if.h>
+
+ #include "bus-error.h"
+ #include "bus-locator.h"
+diff --git a/src/network/networkd-dhcp-prefix-delegation.c b/src/network/networkd-dhcp-prefix-delegation.c
+index 66c5e979d9..581b6b8c29 100644
+--- a/src/network/networkd-dhcp-prefix-delegation.c
++++ b/src/network/networkd-dhcp-prefix-delegation.c
+@@ -1,7 +1,5 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+-#include <linux/ipv6_route.h>
+-
+ #include "sd-dhcp6-client.h"
+
+ #include "hashmap.h"
+@@ -21,6 +19,8 @@
+ #include "strv.h"
+ #include "tunnel.h"
+
++#include <linux/ipv6_route.h>
++
+ bool link_dhcp_pd_is_enabled(Link *link) {
+         assert(link);
+
+diff --git a/src/network/networkd-dhcp-server.c b/src/network/networkd-dhcp-server.c
+index 620fbbddc7..c8af20fb34 100644
+--- a/src/network/networkd-dhcp-server.c
++++ b/src/network/networkd-dhcp-server.c
+@@ -1,7 +1,7 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+ #include <netinet/in.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/if.h>
+
+ #include "sd-dhcp-server.h"
+diff --git a/src/network/networkd-dhcp4.c b/src/network/networkd-dhcp4.c
+index d4b4942173..3d78da5609 100644
+--- a/src/network/networkd-dhcp4.c
++++ b/src/network/networkd-dhcp4.c
+@@ -3,7 +3,7 @@
+ #include <netinet/in.h>
+ #include <netinet/ip.h>
+ #include <linux/if.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+
+ #include "alloc-util.h"
+ #include "dhcp-client-internal.h"
+diff --git a/src/network/networkd-ipv6ll.c b/src/network/networkd-ipv6ll.c
+index 32229a3fc7..662a345d6e 100644
+--- a/src/network/networkd-ipv6ll.c
++++ b/src/network/networkd-ipv6ll.c
+@@ -1,7 +1,7 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+ #include <linux/if.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+
+ #include "in-addr-util.h"
+ #include "networkd-address.h"
+diff --git a/src/network/networkd-link.c b/src/network/networkd-link.c
+index 019bef0590..657fc41ae6 100644
+--- a/src/network/networkd-link.c
++++ b/src/network/networkd-link.c
+@@ -3,7 +3,7 @@
+ #include <net/if.h>
+ #include <netinet/in.h>
+ #include <linux/if.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/if_link.h>
+ #include <linux/netdevice.h>
+ #include <sys/socket.h>
+diff --git a/src/network/networkd-ndisc.c b/src/network/networkd-ndisc.c
+index 99a07e16fc..e51cd81d96 100644
+--- a/src/network/networkd-ndisc.c
++++ b/src/network/networkd-ndisc.c
+@@ -6,7 +6,7 @@
+ #include <arpa/inet.h>
+ #include <netinet/icmp6.h>
+ #include <linux/if.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+
+ #include "sd-ndisc.h"
+
+diff --git a/src/network/networkd-route.c b/src/network/networkd-route.c
+index 5214a8ad2c..9dd758daae 100644
+--- a/src/network/networkd-route.c
++++ b/src/network/networkd-route.c
+@@ -1,9 +1,5 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+-#include <linux/icmpv6.h>
+-#include <linux/ipv6_route.h>
+-#include <linux/nexthop.h>
+-
+ #include "alloc-util.h"
+ #include "event-util.h"
+ #include "netlink-util.h"
+@@ -21,6 +17,10 @@
+ #include "vrf.h"
+ #include "wireguard.h"
+
++#include <linux/icmpv6.h>
++#include <linux/ipv6_route.h>
++#include <linux/nexthop.h>
++
+ int route_new(Route **ret) {
+         _cleanup_(route_freep) Route *route = NULL;
+
+diff --git a/src/network/networkd-setlink.c b/src/network/networkd-setlink.c
+index 541c4b8a72..06ebda8f0f 100644
+--- a/src/network/networkd-setlink.c
++++ b/src/network/networkd-setlink.c
+@@ -2,7 +2,7 @@
+
+ #include <netinet/in.h>
+ #include <linux/if.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/if_bridge.h>
+
+ #include "missing_network.h"
+diff --git a/src/shared/linux/ethtool.h b/src/shared/linux/ethtool.h
+index 1458de3627..d5c2d2e0ac 100644
+--- a/src/shared/linux/ethtool.h
++++ b/src/shared/linux/ethtool.h
+@@ -16,7 +16,8 @@
+
+ #include <linux/const.h>
+ #include <linux/types.h>
+-#include <linux/if_ether.h>
++#include <netinet/if_ether.h>
++//#include <linux/if_ether.h>
+
+ #include <limits.h> /* for INT_MAX */
+
+diff --git a/src/shared/netif-util.c b/src/shared/netif-util.c
+index f56c5646c1..5af28ff119 100644
+--- a/src/shared/netif-util.c
++++ b/src/shared/netif-util.c
+@@ -1,7 +1,7 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+ #include <linux/if.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+
+ #include "arphrd-util.h"
+ #include "device-util.h"
+diff --git a/src/udev/udev-builtin-net_id.c b/src/udev/udev-builtin-net_id.c
+index a48d5dedf8..31a8bc1b3c 100644
+--- a/src/udev/udev-builtin-net_id.c
++++ b/src/udev/udev-builtin-net_id.c
+@@ -18,7 +18,7 @@
+ #include <stdarg.h>
+ #include <unistd.h>
+ #include <linux/if.h>
+-#include <linux/if_arp.h>
++//#include <linux/if_arp.h>
+ #include <linux/netdevice.h>
+ #include <linux/pci_regs.h>
+
+--
+2.39.2

--- a/sd-measure/patches/0003-errno-util-Make-STRERROR-portable-for-musl.patch
+++ b/sd-measure/patches/0003-errno-util-Make-STRERROR-portable-for-musl.patch
@@ -1,0 +1,41 @@
+From f629a76e0fba300a9d511614160fee38dd4a5e57 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 23 Jan 2023 23:39:46 -0800
+Subject: [PATCH] errno-util: Make STRERROR portable for musl
+
+Sadly, systemd has decided to use yet another GNU extention in a macro
+lets make this such that we can use XSI compliant strerror_r() for
+non-glibc hosts
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/basic/errno-util.h | 12 ++++++++++--
+ 1 file changed, 10 insertions(+), 2 deletions(-)
+
+diff --git a/src/basic/errno-util.h b/src/basic/errno-util.h
+index 091f99c590..eb5c1f9961 100644
+--- a/src/basic/errno-util.h
++++ b/src/basic/errno-util.h
+@@ -14,8 +14,16 @@
+  * https://stackoverflow.com/questions/34880638/compound-literal-lifetime-and-if-blocks
+  *
+  * Note that we use the GNU variant of strerror_r() here. */
+-#define STRERROR(errnum) strerror_r(abs(errnum), (char[ERRNO_BUF_LEN]){}, ERRNO_BUF_LEN)
+-
++static inline const char * STRERROR(int errnum);
++
++static inline const char * STRERROR(int errnum) {
++#ifdef __GLIBC__
++        return strerror_r(abs(errnum), (char[ERRNO_BUF_LEN]){}, ERRNO_BUF_LEN);
++#else
++        static __thread char buf[ERRNO_BUF_LEN];
++        return strerror_r(abs(errnum), buf, ERRNO_BUF_LEN) ? "unknown error" : buf;
++#endif
++}
+ /* A helper to print an error message or message for functions that return 0 on EOF.
+  * Note that we can't use ({ … }) to define a temporary variable, so errnum is
+  * evaluated twice. */
+--
+2.39.2

--- a/sd-measure/patches/0005-pass-correct-parameters-to-getdents64.patch
+++ b/sd-measure/patches/0005-pass-correct-parameters-to-getdents64.patch
@@ -1,0 +1,36 @@
+From 17766c64ecc7dedf09ed2d361690fc4eda77bf42 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 21 Jan 2022 15:15:11 -0800
+Subject: [PATCH] pass correct parameters to getdents64
+
+Fixes
+../git/src/basic/recurse-dir.c:57:40: error: incompatible pointer types passing 'uint8_t *' (aka 'unsigned char *') to parameter of type 'struct dirent *' [-Werror,-Wincompatible-pointer-types]
+                n = getdents64(dir_fd, (uint8_t*) de->buffer + de->buffer_size, bs - de->buffer_size);
+                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+../git/src/basic/stat-util.c:102:28: error: incompatible pointer types passing 'union (unnamed union at ../git/src/basic/stat-util.c:78:9) *' to parameter of type 'struct dirent *' [-Werror,-Wincompatible-pointer-types]
+        n = getdents64(fd, &buffer, sizeof(buffer));
+                           ^~~~~~~
+
+Upstream-Status: Inappropriate [musl specific]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Jiaqing Zhao <jiaqing.zhao@linux.intel.com>
+---
+ src/basic/recurse-dir.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/basic/recurse-dir.c b/src/basic/recurse-dir.c
+index 5e98b7a5d8..aef065047b 100644
+--- a/src/basic/recurse-dir.c
++++ b/src/basic/recurse-dir.c
+@@ -55,7 +55,7 @@ int readdir_all(int dir_fd,
+                 bs = MIN(MALLOC_SIZEOF_SAFE(de) - offsetof(DirectoryEntries, buffer), (size_t) SSIZE_MAX);
+                 assert(bs > de->buffer_size);
+
+-                n = getdents64(dir_fd, (uint8_t*) de->buffer + de->buffer_size, bs - de->buffer_size);
++                n = getdents64(dir_fd, (struct dirent*)((uint8_t*) de->buffer + de->buffer_size), bs - de->buffer_size);
+                 if (n < 0)
+                         return -errno;
+                 if (n == 0)
+--
+2.39.2

--- a/sd-measure/patches/0006-test-bus-error-strerror-is-assumed-to-be-GNU-specifi.patch
+++ b/sd-measure/patches/0006-test-bus-error-strerror-is-assumed-to-be-GNU-specifi.patch
@@ -1,0 +1,51 @@
+From fa598869cca684c001f3dc23ce2198f5a6169e2a Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Tue, 8 Nov 2022 13:31:34 -0800
+Subject: [PATCH] test-bus-error: strerror() is assumed to be GNU specific
+ version mark it so
+
+Upstream-Status: Inappropriate [Upstream systemd only supports glibc]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/libsystemd/sd-bus/test-bus-error.c | 2 ++
+ src/test/test-errno-util.c             | 3 ++-
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/src/libsystemd/sd-bus/test-bus-error.c b/src/libsystemd/sd-bus/test-bus-error.c
+index a55f3f9856..4123bf3da0 100644
+--- a/src/libsystemd/sd-bus/test-bus-error.c
++++ b/src/libsystemd/sd-bus/test-bus-error.c
+@@ -99,7 +99,9 @@ TEST(error) {
+         assert_se(!sd_bus_error_is_set(&error));
+         assert_se(sd_bus_error_set_errno(&error, EBUSY) == -EBUSY);
+         assert_se(streq(error.name, "System.Error.EBUSY"));
++#ifdef __GLIBC__
+         assert_se(streq(error.message, STRERROR(EBUSY)));
++#endif
+         assert_se(sd_bus_error_has_name(&error, "System.Error.EBUSY"));
+         assert_se(sd_bus_error_get_errno(&error) == EBUSY);
+         assert_se(sd_bus_error_is_set(&error));
+diff --git a/src/test/test-errno-util.c b/src/test/test-errno-util.c
+index d3d022c33f..74e95c804d 100644
+--- a/src/test/test-errno-util.c
++++ b/src/test/test-errno-util.c
+@@ -4,7 +4,7 @@
+ #include "stdio-util.h"
+ #include "string-util.h"
+ #include "tests.h"
+-
++#ifdef __GLIBC__
+ TEST(strerror_not_threadsafe) {
+         /* Just check that strerror really is not thread-safe. */
+         log_info("strerror(%d) → %s", 200, strerror(200));
+@@ -46,6 +46,7 @@ TEST(STRERROR_OR_ELSE) {
+         log_info("STRERROR_OR_ELSE(EPERM, \"EOF\") → %s", STRERROR_OR_EOF(EPERM));
+         log_info("STRERROR_OR_ELSE(-EPERM, \"EOF\") → %s", STRERROR_OR_EOF(-EPERM));
+ }
++#endif /* __GLIBC__ */
+
+ TEST(PROTECT_ERRNO) {
+         errno = 12;
+--
+2.39.2

--- a/sd-measure/patches/0007-Add-sys-stat.h-for-S_IFDIR.patch
+++ b/sd-measure/patches/0007-Add-sys-stat.h-for-S_IFDIR.patch
@@ -1,0 +1,28 @@
+From 1480ef4ea9f71befbc22272c219b62ee5cd71d43 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 21 Jan 2022 15:17:37 -0800
+Subject: [PATCH] Add sys/stat.h for S_IFDIR
+
+../git/src/shared/mkdir-label.c:13:61: error: use of undeclared identifier 'S_IFDIR'
+        r = mac_selinux_create_file_prepare_at(dirfd, path, S_IFDIR);
+
+Upstream-Status: Backport [29b7114c5d9624002aa7c17748d960cd1e45362d]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/shared/mkdir-label.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/shared/mkdir-label.c b/src/shared/mkdir-label.c
+index e3afc2b666..f1df778966 100644
+--- a/src/shared/mkdir-label.c
++++ b/src/shared/mkdir-label.c
+@@ -7,6 +7,7 @@
+ #include "selinux-util.h"
+ #include "smack-util.h"
+ #include "user-util.h"
++#include <sys/stat.h>
+
+ int mkdirat_label(int dirfd, const char *path, mode_t mode) {
+         int r;
+--
+2.39.2

--- a/sd-measure/patches/0009-missing_type.h-add-comparison_fn_t.patch
+++ b/sd-measure/patches/0009-missing_type.h-add-comparison_fn_t.patch
@@ -1,0 +1,61 @@
+From 542f999a846dfd49d9373d30fffb2a44168d7b5e Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Mon, 25 Feb 2019 13:55:12 +0800
+Subject: [PATCH] missing_type.h: add comparison_fn_t
+
+Make it work with musl where comparison_fn_t and is not provided.
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Alex Kiernan <alex.kiernan@gmail.com>
+[Rebased for v244]
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[Rebased for v242]
+Signed-off-by: Andrej Valek <andrej.valek@siemens.com>
+[Rebased for v250, Drop __compare_fn_t]
+Signed-off-by: Jiaqing Zhao <jiaqing.zhao@linux.intel.com>
+---
+ src/basic/missing_type.h            | 4 ++++
+ src/basic/sort-util.h               | 1 +
+ src/libsystemd/sd-journal/catalog.c | 1 +
+ 3 files changed, 6 insertions(+)
+
+diff --git a/src/basic/missing_type.h b/src/basic/missing_type.h
+index f6233090a9..6c0456349d 100644
+--- a/src/basic/missing_type.h
++++ b/src/basic/missing_type.h
+@@ -10,3 +10,7 @@
+ #if !HAVE_CHAR16_T
+ #define char16_t uint16_t
+ #endif
++
++#ifndef __GLIBC__
++typedef int (*comparison_fn_t)(const void *, const void *);
++#endif
+diff --git a/src/basic/sort-util.h b/src/basic/sort-util.h
+index f0bf246aa3..33669c7a75 100644
+--- a/src/basic/sort-util.h
++++ b/src/basic/sort-util.h
+@@ -4,6 +4,7 @@
+ #include <stdlib.h>
+ 
+ #include "macro.h"
++#include "missing_type.h"
+ 
+ /* This is the same as glibc's internal __compar_d_fn_t type. glibc exports a public comparison_fn_t, for the
+  * external type __compar_fn_t, but doesn't do anything similar for __compar_d_fn_t. Let's hence do that
+diff --git a/src/libsystemd/sd-journal/catalog.c b/src/libsystemd/sd-journal/catalog.c
+index 7527abf636..f33383e57f 100644
+--- a/src/libsystemd/sd-journal/catalog.c
++++ b/src/libsystemd/sd-journal/catalog.c
+@@ -28,6 +28,7 @@
+ #include "string-util.h"
+ #include "strv.h"
+ #include "tmpfile-util.h"
++#include "missing_type.h"
+ 
+ const char * const catalog_file_dirs[] = {
+         "/usr/local/lib/systemd/catalog/",
+-- 
+2.39.2
+

--- a/sd-measure/patches/0010-add-fallback-parse_printf_format-implementation.patch
+++ b/sd-measure/patches/0010-add-fallback-parse_printf_format-implementation.patch
@@ -1,0 +1,416 @@
+From 383e85e15f16a46aac925aa439b8b60f58b40aa6 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Sat, 22 May 2021 20:26:24 +0200
+Subject: [PATCH] add fallback parse_printf_format implementation
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Emil Renner Berthing <systemd@esmil.dk>
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[rebased for systemd 243]
+Signed-off-by: Scott Murray <scott.murray@konsulko.com>
+---
+ meson.build                              |   1 +
+ src/basic/meson.build                    |   5 +
+ src/basic/parse-printf-format.c          | 273 +++++++++++++++++++++++
+ src/basic/parse-printf-format.h          |  57 +++++
+ src/basic/stdio-util.h                   |   2 +-
+ src/libsystemd/sd-journal/journal-send.c |   2 +-
+ 6 files changed, 338 insertions(+), 2 deletions(-)
+ create mode 100644 src/basic/parse-printf-format.c
+ create mode 100644 src/basic/parse-printf-format.h
+
+--- a/meson.build
++++ b/meson.build
+@@ -755,6 +755,7 @@ endif
+ foreach header : ['crypt.h',
+                   'linux/memfd.h',
+                   'linux/vm_sockets.h',
++                  'printf.h',
+                   'sys/auxv.h',
+                   'threads.h',
+                   'valgrind/memcheck.h',
+--- a/src/basic/meson.build
++++ b/src/basic/meson.build
+@@ -173,6 +173,11 @@ endforeach
+
+ basic_sources += generated_gperf_headers
+
++if conf.get('HAVE_PRINTF_H') != 1
++        basic_sources += [files('parse-printf-format.c')]
++endif
++
++
+ ############################################################
+
+ arch_list = [
+--- /dev/null
++++ b/src/basic/parse-printf-format.c
+@@ -0,0 +1,273 @@
++/*-*- Mode: C; c-basic-offset: 8; indent-tabs-mode: nil -*-*/
++
++/***
++  This file is part of systemd.
++
++  Copyright 2014 Emil Renner Berthing <systemd@esmil.dk>
++
++  With parts from the musl C library
++  Copyright 2005-2014 Rich Felker, et al.
++
++  systemd is free software; you can redistribute it and/or modify it
++  under the terms of the GNU Lesser General Public License as published by
++  the Free Software Foundation; either version 2.1 of the License, or
++  (at your option) any later version.
++
++  systemd is distributed in the hope that it will be useful, but
++  WITHOUT ANY WARRANTY; without even the implied warranty of
++  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
++  Lesser General Public License for more details.
++
++  You should have received a copy of the GNU Lesser General Public License
++  along with systemd; If not, see <http://www.gnu.org/licenses/>.
++***/
++
++#include <stddef.h>
++#include <string.h>
++
++#include "parse-printf-format.h"
++
++static const char *consume_nonarg(const char *fmt)
++{
++        do {
++                if (*fmt == '\0')
++                        return fmt;
++        } while (*fmt++ != '%');
++        return fmt;
++}
++
++static const char *consume_num(const char *fmt)
++{
++        for (;*fmt >= '0' && *fmt <= '9'; fmt++)
++                /* do nothing */;
++        return fmt;
++}
++
++static const char *consume_argn(const char *fmt, size_t *arg)
++{
++        const char *p = fmt;
++        size_t val = 0;
++
++        if (*p < '1' || *p > '9')
++                return fmt;
++        do {
++                val = 10*val + (*p++ - '0');
++        } while (*p >= '0' && *p <= '9');
++
++        if (*p != '$')
++                return fmt;
++        *arg = val;
++        return p+1;
++}
++
++static const char *consume_flags(const char *fmt)
++{
++        while (1) {
++                switch (*fmt) {
++                case '#':
++                case '0':
++                case '-':
++                case ' ':
++                case '+':
++                case '\'':
++                case 'I':
++                        fmt++;
++                        continue;
++                }
++                return fmt;
++        }
++}
++
++enum state {
++        BARE,
++        LPRE,
++        LLPRE,
++        HPRE,
++        HHPRE,
++        BIGLPRE,
++        ZTPRE,
++        JPRE,
++        STOP
++};
++
++enum type {
++        NONE,
++        PTR,
++        INT,
++        UINT,
++        ULLONG,
++        LONG,
++        ULONG,
++        SHORT,
++        USHORT,
++        CHAR,
++        UCHAR,
++        LLONG,
++        SIZET,
++        IMAX,
++        UMAX,
++        PDIFF,
++        UIPTR,
++        DBL,
++        LDBL,
++        MAXTYPE
++};
++
++static const short pa_types[MAXTYPE] = {
++        [NONE]   = PA_INT,
++        [PTR]    = PA_POINTER,
++        [INT]    = PA_INT,
++        [UINT]   = PA_INT,
++        [ULLONG] = PA_INT | PA_FLAG_LONG_LONG,
++        [LONG]   = PA_INT | PA_FLAG_LONG,
++        [ULONG]  = PA_INT | PA_FLAG_LONG,
++        [SHORT]  = PA_INT | PA_FLAG_SHORT,
++        [USHORT] = PA_INT | PA_FLAG_SHORT,
++        [CHAR]   = PA_CHAR,
++        [UCHAR]  = PA_CHAR,
++        [LLONG]  = PA_INT | PA_FLAG_LONG_LONG,
++        [SIZET]  = PA_INT | PA_FLAG_LONG,
++        [IMAX]   = PA_INT | PA_FLAG_LONG_LONG,
++        [UMAX]   = PA_INT | PA_FLAG_LONG_LONG,
++        [PDIFF]  = PA_INT | PA_FLAG_LONG_LONG,
++        [UIPTR]  = PA_INT | PA_FLAG_LONG,
++        [DBL]    = PA_DOUBLE,
++        [LDBL]   = PA_DOUBLE | PA_FLAG_LONG_DOUBLE
++};
++
++#define S(x) [(x)-'A']
++#define E(x) (STOP + (x))
++
++static const unsigned char states[]['z'-'A'+1] = {
++        { /* 0: bare types */
++                S('d') = E(INT), S('i') = E(INT),
++                S('o') = E(UINT),S('u') = E(UINT),S('x') = E(UINT), S('X') = E(UINT),
++                S('e') = E(DBL), S('f') = E(DBL), S('g') = E(DBL),  S('a') = E(DBL),
++                S('E') = E(DBL), S('F') = E(DBL), S('G') = E(DBL),  S('A') = E(DBL),
++                S('c') = E(CHAR),S('C') = E(INT),
++                S('s') = E(PTR), S('S') = E(PTR), S('p') = E(UIPTR),S('n') = E(PTR),
++                S('m') = E(NONE),
++                S('l') = LPRE,   S('h') = HPRE, S('L') = BIGLPRE,
++                S('z') = ZTPRE,  S('j') = JPRE, S('t') = ZTPRE
++        }, { /* 1: l-prefixed */
++                S('d') = E(LONG), S('i') = E(LONG),
++                S('o') = E(ULONG),S('u') = E(ULONG),S('x') = E(ULONG),S('X') = E(ULONG),
++                S('e') = E(DBL),  S('f') = E(DBL),  S('g') = E(DBL),  S('a') = E(DBL),
++                S('E') = E(DBL),  S('F') = E(DBL),  S('G') = E(DBL),  S('A') = E(DBL),
++                S('c') = E(INT),  S('s') = E(PTR),  S('n') = E(PTR),
++                S('l') = LLPRE
++        }, { /* 2: ll-prefixed */
++                S('d') = E(LLONG), S('i') = E(LLONG),
++                S('o') = E(ULLONG),S('u') = E(ULLONG),
++                S('x') = E(ULLONG),S('X') = E(ULLONG),
++                S('n') = E(PTR)
++        }, { /* 3: h-prefixed */
++                S('d') = E(SHORT), S('i') = E(SHORT),
++                S('o') = E(USHORT),S('u') = E(USHORT),
++                S('x') = E(USHORT),S('X') = E(USHORT),
++                S('n') = E(PTR),
++                S('h') = HHPRE
++        }, { /* 4: hh-prefixed */
++                S('d') = E(CHAR), S('i') = E(CHAR),
++                S('o') = E(UCHAR),S('u') = E(UCHAR),
++                S('x') = E(UCHAR),S('X') = E(UCHAR),
++                S('n') = E(PTR)
++        }, { /* 5: L-prefixed */
++                S('e') = E(LDBL),S('f') = E(LDBL),S('g') = E(LDBL), S('a') = E(LDBL),
++                S('E') = E(LDBL),S('F') = E(LDBL),S('G') = E(LDBL), S('A') = E(LDBL),
++                S('n') = E(PTR)
++        }, { /* 6: z- or t-prefixed (assumed to be same size) */
++                S('d') = E(PDIFF),S('i') = E(PDIFF),
++                S('o') = E(SIZET),S('u') = E(SIZET),
++                S('x') = E(SIZET),S('X') = E(SIZET),
++                S('n') = E(PTR)
++        }, { /* 7: j-prefixed */
++                S('d') = E(IMAX), S('i') = E(IMAX),
++                S('o') = E(UMAX), S('u') = E(UMAX),
++                S('x') = E(UMAX), S('X') = E(UMAX),
++                S('n') = E(PTR)
++        }
++};
++
++size_t parse_printf_format(const char *fmt, size_t n, int *types)
++{
++        size_t i = 0;
++        size_t last = 0;
++
++        memset(types, 0, n);
++
++        while (1) {
++                size_t arg;
++                unsigned int state;
++
++                fmt = consume_nonarg(fmt);
++                if (*fmt == '\0')
++                        break;
++                if (*fmt == '%') {
++                        fmt++;
++                        continue;
++                }
++                arg = 0;
++                fmt = consume_argn(fmt, &arg);
++                /* flags */
++                fmt = consume_flags(fmt);
++                /* width */
++                if (*fmt == '*') {
++                        size_t warg = 0;
++                        fmt = consume_argn(fmt+1, &warg);
++                        if (warg == 0)
++                                warg = ++i;
++                        if (warg > last)
++                                last = warg;
++                        if (warg <= n && types[warg-1] == NONE)
++                                types[warg-1] = INT;
++                } else
++                        fmt = consume_num(fmt);
++                /* precision */
++                if (*fmt == '.') {
++                        fmt++;
++                        if (*fmt == '*') {
++                                size_t parg = 0;
++                                fmt = consume_argn(fmt+1, &parg);
++                                if (parg == 0)
++                                        parg = ++i;
++                                if (parg > last)
++                                        last = parg;
++                                if (parg <= n && types[parg-1] == NONE)
++                                        types[parg-1] = INT;
++                        } else {
++                                if (*fmt == '-')
++                                        fmt++;
++                                fmt = consume_num(fmt);
++                        }
++                }
++                /* length modifier and conversion specifier */
++                state = BARE;
++                do {
++                        unsigned char c = *fmt++;
++
++                        if (c < 'A' || c > 'z')
++                                continue;
++                        state = states[state]S(c);
++                        if (state == 0)
++                                continue;
++                } while (state < STOP);
++
++                if (state == E(NONE))
++                        continue;
++
++                if (arg == 0)
++                        arg = ++i;
++                if (arg > last)
++                        last = arg;
++                if (arg <= n)
++                        types[arg-1] = state - STOP;
++        }
++
++        if (last > n)
++                last = n;
++        for (i = 0; i < last; i++)
++                types[i] = pa_types[types[i]];
++
++        return last;
++}
+--- /dev/null
++++ b/src/basic/parse-printf-format.h
+@@ -0,0 +1,57 @@
++/*-*- Mode: C; c-basic-offset: 8; indent-tabs-mode: nil -*-*/
++
++/***
++  This file is part of systemd.
++
++  Copyright 2014 Emil Renner Berthing <systemd@esmil.dk>
++
++  With parts from the GNU C Library
++  Copyright 1991-2014 Free Software Foundation, Inc.
++
++  systemd is free software; you can redistribute it and/or modify it
++  under the terms of the GNU Lesser General Public License as published by
++  the Free Software Foundation; either version 2.1 of the License, or
++  (at your option) any later version.
++
++  systemd is distributed in the hope that it will be useful, but
++  WITHOUT ANY WARRANTY; without even the implied warranty of
++  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
++  Lesser General Public License for more details.
++
++  You should have received a copy of the GNU Lesser General Public License
++  along with systemd; If not, see <http://www.gnu.org/licenses/>.
++***/
++
++#pragma once
++
++#include "config.h"
++
++#if HAVE_PRINTF_H
++#include <printf.h>
++#else
++
++#include <stddef.h>
++
++enum {				/* C type: */
++  PA_INT,			/* int */
++  PA_CHAR,			/* int, cast to char */
++  PA_WCHAR,			/* wide char */
++  PA_STRING,			/* const char *, a '\0'-terminated string */
++  PA_WSTRING,			/* const wchar_t *, wide character string */
++  PA_POINTER,			/* void * */
++  PA_FLOAT,			/* float */
++  PA_DOUBLE,			/* double */
++  PA_LAST
++};
++
++/* Flag bits that can be set in a type returned by `parse_printf_format'.  */
++#define	PA_FLAG_MASK		0xff00
++#define	PA_FLAG_LONG_LONG	(1 << 8)
++#define	PA_FLAG_LONG_DOUBLE	PA_FLAG_LONG_LONG
++#define	PA_FLAG_LONG		(1 << 9)
++#define	PA_FLAG_SHORT		(1 << 10)
++#define	PA_FLAG_PTR		(1 << 11)
++
++size_t parse_printf_format(const char *fmt, size_t n, int *types);
++
++#endif /* HAVE_PRINTF_H */
+--- a/src/basic/stdio-util.h
++++ b/src/basic/stdio-util.h
+@@ -1,12 +1,12 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ #pragma once
+
+-#include <printf.h>
+ #include <stdarg.h>
+ #include <stdio.h>
+ #include <sys/types.h>
+
+ #include "macro.h"
++#include "parse-printf-format.h"
+
+ _printf_(3, 4)
+ static inline char *snprintf_ok(char *buf, size_t len, const char *format, ...) {
+--- a/src/libsystemd/sd-journal/journal-send.c
++++ b/src/libsystemd/sd-journal/journal-send.c
+@@ -2,7 +2,6 @@
+
+ #include <errno.h>
+ #include <fcntl.h>
+-#include <printf.h>
+ #include <stddef.h>
+ #include <sys/un.h>
+ #include <unistd.h>
+@@ -25,6 +24,7 @@
+ #include "stdio-util.h"
+ #include "string-util.h"
+ #include "tmpfile-util.h"
++#include "parse-printf-format.h"
+
+ #define SNDBUF_SIZE (8*1024*1024)

--- a/sd-measure/patches/0011-src-basic-missing.h-check-for-missing-strndupa.patch
+++ b/sd-measure/patches/0011-src-basic-missing.h-check-for-missing-strndupa.patch
@@ -1,0 +1,682 @@
+From ee5c8b494a3269edd154a0b799a03b39dba2ceb0 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Mon, 25 Feb 2019 14:18:21 +0800
+Subject: [PATCH] src/basic/missing.h: check for missing strndupa
+
+include missing.h  for definition of strndupa
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[Rebased for v242]
+Signed-off-by: Andrej Valek <andrej.valek@siemens.com>
+[rebased for systemd 243]
+Signed-off-by: Scott Murray <scott.murray@konsulko.com>
+Signed-off-by: Alex Kiernan <alex.kiernan@gmail.com>
+[rebased for systemd 244]
+[Rebased for v247]
+Signed-off-by: Luca Boccassi <luca.boccassi@microsoft.com>
+---
+ meson.build                                |  1 +
+ src/backlight/backlight.c                  |  1 +
+ src/basic/cgroup-util.c                    |  1 +
+ src/basic/env-util.c                       |  1 +
+ src/basic/log.c                            |  1 +
+ src/basic/missing_stdlib.h                 | 12 ++++++++++++
+ src/basic/mkdir.c                          |  1 +
+ src/basic/mountpoint-util.c                |  1 +
+ src/basic/parse-util.c                     |  1 +
+ src/basic/path-lookup.c                    |  1 +
+ src/basic/percent-util.c                   |  1 +
+ src/basic/proc-cmdline.c                   |  1 +
+ src/basic/procfs-util.c                    |  1 +
+ src/basic/time-util.c                      |  1 +
+ src/boot/bless-boot.c                      |  1 +
+ src/core/dbus-cgroup.c                     |  1 +
+ src/core/dbus-execute.c                    |  1 +
+ src/core/dbus-util.c                       |  1 +
+ src/core/execute.c                         |  1 +
+ src/core/kmod-setup.c                      |  1 +
+ src/core/service.c                         |  1 +
+ src/coredump/coredump-vacuum.c             |  1 +
+ src/fstab-generator/fstab-generator.c      |  1 +
+ src/journal-remote/journal-remote-main.c   |  1 +
+ src/journal/journalctl.c                   |  1 +
+ src/libsystemd/sd-bus/bus-message.c        |  1 +
+ src/libsystemd/sd-bus/bus-objects.c        |  1 +
+ src/libsystemd/sd-bus/bus-socket.c         |  1 +
+ src/libsystemd/sd-bus/sd-bus.c             |  1 +
+ src/libsystemd/sd-bus/test-bus-benchmark.c |  1 +
+ src/libsystemd/sd-journal/sd-journal.c     |  1 +
+ src/login/pam_systemd.c                    |  1 +
+ src/network/generator/network-generator.c  |  1 +
+ src/nspawn/nspawn-settings.c               |  1 +
+ src/nss-mymachines/nss-mymachines.c        |  1 +
+ src/portable/portable.c                    |  1 +
+ src/resolve/resolvectl.c                   |  1 +
+ src/shared/bus-get-properties.c            |  1 +
+ src/shared/bus-unit-procs.c                |  1 +
+ src/shared/bus-unit-util.c                 |  1 +
+ src/shared/bus-util.c                      |  1 +
+ src/shared/dns-domain.c                    |  1 +
+ src/shared/journal-importer.c              |  1 +
+ src/shared/logs-show.c                     |  1 +
+ src/shared/pager.c                         |  1 +
+ src/socket-proxy/socket-proxyd.c           |  1 +
+ src/test/test-hexdecoct.c                  |  1 +
+ src/udev/udev-builtin-path_id.c            |  1 +
+ src/udev/udev-event.c                      |  1 +
+ src/udev/udev-rules.c                      |  1 +
+ 50 files changed, 61 insertions(+)
+
+diff --git a/meson.build b/meson.build
+index fb96143c37..739b2f7f72 100644
+--- a/meson.build
++++ b/meson.build
+@@ -574,6 +574,7 @@ foreach ident : ['secure_getenv', '__secure_getenv']
+ endforeach
+
+ foreach ident : [
++        ['strndupa' ,         '''#include <string.h>'''],
+         ['memfd_create',      '''#include <sys/mman.h>'''],
+         ['gettid',            '''#include <sys/types.h>
+                                  #include <unistd.h>'''],
+diff --git a/src/backlight/backlight.c b/src/backlight/backlight.c
+index e66477f328..2613d1e3f9 100644
+--- a/src/backlight/backlight.c
++++ b/src/backlight/backlight.c
+@@ -19,6 +19,7 @@
+ #include "string-util.h"
+ #include "strv.h"
+ #include "terminal-util.h"
++#include "missing_stdlib.h"
+
+ #define PCI_CLASS_GRAPHICS_CARD 0x30000
+
+diff --git a/src/basic/cgroup-util.c b/src/basic/cgroup-util.c
+index feda596939..11b4375ed5 100644
+--- a/src/basic/cgroup-util.c
++++ b/src/basic/cgroup-util.c
+@@ -37,6 +37,7 @@
+ #include "unit-name.h"
+ #include "user-util.h"
+ #include "xattr-util.h"
++#include "missing_stdlib.h"
+
+ static int cg_enumerate_items(const char *controller, const char *path, FILE **_f, const char *item) {
+         _cleanup_free_ char *fs = NULL;
+diff --git a/src/basic/env-util.c b/src/basic/env-util.c
+index 55ac11a512..7ccb1d7887 100644
+--- a/src/basic/env-util.c
++++ b/src/basic/env-util.c
+@@ -19,6 +19,7 @@
+ #include "string-util.h"
+ #include "strv.h"
+ #include "utf8.h"
++#include "missing_stdlib.h"
+
+ /* We follow bash for the character set. Different shells have different rules. */
+ #define VALID_BASH_ENV_NAME_CHARS               \
+diff --git a/src/basic/log.c b/src/basic/log.c
+index fc5793139e..515218fca8 100644
+--- a/src/basic/log.c
++++ b/src/basic/log.c
+@@ -39,6 +39,7 @@
+ #include "terminal-util.h"
+ #include "time-util.h"
+ #include "utf8.h"
++#include "missing_stdlib.h"
+
+ #define SNDBUF_SIZE (8*1024*1024)
+ #define IOVEC_MAX 128U
+diff --git a/src/basic/missing_stdlib.h b/src/basic/missing_stdlib.h
+index 8c76f93eb2..9068bfb4f0 100644
+--- a/src/basic/missing_stdlib.h
++++ b/src/basic/missing_stdlib.h
+@@ -11,3 +11,15 @@
+ #    error "neither secure_getenv nor __secure_getenv are available"
+ #  endif
+ #endif
++
++/* string.h */
++#if ! HAVE_STRNDUPA
++#define strndupa(s, n) \
++  ({ \
++    const char *__old = (s); \
++    size_t __len = strnlen(__old, (n)); \
++    char *__new = (char *)alloca(__len + 1); \
++    __new[__len] = '\0'; \
++    (char *)memcpy(__new, __old, __len); \
++  })
++#endif
+diff --git a/src/basic/mkdir.c b/src/basic/mkdir.c
+index 7ad19ee33b..cc1d5e1e5b 100644
+--- a/src/basic/mkdir.c
++++ b/src/basic/mkdir.c
+@@ -15,6 +15,7 @@
+ #include "stat-util.h"
+ #include "stdio-util.h"
+ #include "user-util.h"
++#include "missing_stdlib.h"
+
+ int mkdirat_safe_internal(
+                 int dir_fd,
+diff --git a/src/basic/mountpoint-util.c b/src/basic/mountpoint-util.c
+index bc74fbef8f..cdb609bb84 100644
+--- a/src/basic/mountpoint-util.c
++++ b/src/basic/mountpoint-util.c
+@@ -13,6 +13,7 @@
+ #include "missing_stat.h"
+ #include "missing_syscall.h"
+ #include "mkdir.h"
++#include "missing_stdlib.h"
+ #include "mountpoint-util.h"
+ #include "nulstr-util.h"
+ #include "parse-util.h"
+diff --git a/src/basic/parse-util.c b/src/basic/parse-util.c
+index 3445d31307..d82b4415d9 100644
+--- a/src/basic/parse-util.c
++++ b/src/basic/parse-util.c
+@@ -18,6 +18,7 @@
+ #include "stat-util.h"
+ #include "string-util.h"
+ #include "strv.h"
++#include "missing_stdlib.h"
+
+ int parse_boolean(const char *v) {
+         if (!v)
+diff --git a/src/basic/path-lookup.c b/src/basic/path-lookup.c
+index c99e9d8786..71a917a0b0 100644
+--- a/src/basic/path-lookup.c
++++ b/src/basic/path-lookup.c
+@@ -16,6 +16,7 @@
+ #include "strv.h"
+ #include "tmpfile-util.h"
+ #include "user-util.h"
++#include "missing_stdlib.h"
+
+ int xdg_user_runtime_dir(char **ret, const char *suffix) {
+         const char *e;
+diff --git a/src/basic/percent-util.c b/src/basic/percent-util.c
+index cab9d0eaea..5f6ca258e9 100644
+--- a/src/basic/percent-util.c
++++ b/src/basic/percent-util.c
+@@ -3,6 +3,7 @@
+ #include "percent-util.h"
+ #include "string-util.h"
+ #include "parse-util.h"
++#include "missing_stdlib.h"
+
+ static int parse_parts_value_whole(const char *p, const char *symbol) {
+         const char *pc, *n;
+diff --git a/src/basic/proc-cmdline.c b/src/basic/proc-cmdline.c
+index eea70d8606..ae3abd8402 100644
+--- a/src/basic/proc-cmdline.c
++++ b/src/basic/proc-cmdline.c
+@@ -15,6 +15,7 @@
+ #include "special.h"
+ #include "string-util.h"
+ #include "virt.h"
++#include "missing_stdlib.h"
+
+ int proc_cmdline(char **ret) {
+         const char *e;
+diff --git a/src/basic/procfs-util.c b/src/basic/procfs-util.c
+index bcba5a5208..64a95dd866 100644
+--- a/src/basic/procfs-util.c
++++ b/src/basic/procfs-util.c
+@@ -12,6 +12,7 @@
+ #include "procfs-util.h"
+ #include "stdio-util.h"
+ #include "string-util.h"
++#include "missing_stdlib.h"
+
+ int procfs_get_pid_max(uint64_t *ret) {
+         _cleanup_free_ char *value = NULL;
+diff --git a/src/basic/time-util.c b/src/basic/time-util.c
+index b700f364ef..48a26bcec9 100644
+--- a/src/basic/time-util.c
++++ b/src/basic/time-util.c
+@@ -26,6 +26,7 @@
+ #include "string-util.h"
+ #include "strv.h"
+ #include "time-util.h"
++#include "missing_stdlib.h"
+
+ static clockid_t map_clock_id(clockid_t c) {
+
+diff --git a/src/boot/bless-boot.c b/src/boot/bless-boot.c
+index 59f02b761a..7496646350 100644
+--- a/src/boot/bless-boot.c
++++ b/src/boot/bless-boot.c
+@@ -22,6 +22,7 @@
+ #include "terminal-util.h"
+ #include "verbs.h"
+ #include "virt.h"
++#include "missing_stdlib.h"
+
+ static char **arg_path = NULL;
+
+diff --git a/src/core/dbus-cgroup.c b/src/core/dbus-cgroup.c
+index b5484eda78..54ed62c790 100644
+--- a/src/core/dbus-cgroup.c
++++ b/src/core/dbus-cgroup.c
+@@ -21,6 +21,7 @@
+ #include "parse-util.h"
+ #include "path-util.h"
+ #include "percent-util.h"
++#include "missing_stdlib.h"
+ #include "socket-util.h"
+
+ BUS_DEFINE_PROPERTY_GET(bus_property_get_tasks_max, "t", TasksMax, tasks_max_resolve);
+diff --git a/src/core/dbus-execute.c b/src/core/dbus-execute.c
+index f514b8fd12..4febd0d496 100644
+--- a/src/core/dbus-execute.c
++++ b/src/core/dbus-execute.c
+@@ -45,6 +45,7 @@
+ #include "unit-printf.h"
+ #include "user-util.h"
+ #include "utf8.h"
++#include "missing_stdlib.h"
+
+ BUS_DEFINE_PROPERTY_GET_ENUM(bus_property_get_exec_output, exec_output, ExecOutput);
+ static BUS_DEFINE_PROPERTY_GET_ENUM(property_get_exec_input, exec_input, ExecInput);
+diff --git a/src/core/dbus-util.c b/src/core/dbus-util.c
+index edfa0eb69a..6fd2ec9062 100644
+--- a/src/core/dbus-util.c
++++ b/src/core/dbus-util.c
+@@ -9,6 +9,7 @@
+ #include "unit-printf.h"
+ #include "user-util.h"
+ #include "unit.h"
++#include "missing_stdlib.h"
+
+ int bus_property_get_triggered_unit(
+                 sd_bus *bus,
+diff --git a/src/core/execute.c b/src/core/execute.c
+index 853e87450f..8ef76de9ab 100644
+--- a/src/core/execute.c
++++ b/src/core/execute.c
+@@ -105,6 +105,7 @@
+ #include "unit-serialize.h"
+ #include "user-util.h"
+ #include "utmp-wtmp.h"
++#include "missing_stdlib.h"
+
+ #define IDLE_TIMEOUT_USEC (5*USEC_PER_SEC)
+ #define IDLE_TIMEOUT2_USEC (1*USEC_PER_SEC)
+diff --git a/src/core/kmod-setup.c b/src/core/kmod-setup.c
+index e843743777..e149807492 100644
+--- a/src/core/kmod-setup.c
++++ b/src/core/kmod-setup.c
+@@ -12,6 +12,7 @@
+ #include "recurse-dir.h"
+ #include "string-util.h"
+ #include "virt.h"
++#include "missing_stdlib.h"
+
+ #if HAVE_KMOD
+ #include "module-util.h"
+diff --git a/src/core/service.c b/src/core/service.c
+index 9ad3c3d995..b112d64919 100644
+--- a/src/core/service.c
++++ b/src/core/service.c
+@@ -42,6 +42,7 @@
+ #include "unit-name.h"
+ #include "unit.h"
+ #include "utf8.h"
++#include "missing_stdlib.h"
+
+ #define service_spawn(...) service_spawn_internal(__func__, __VA_ARGS__)
+
+diff --git a/src/coredump/coredump-vacuum.c b/src/coredump/coredump-vacuum.c
+index c6e201ecf2..ab034475e2 100644
+--- a/src/coredump/coredump-vacuum.c
++++ b/src/coredump/coredump-vacuum.c
+@@ -17,6 +17,7 @@
+ #include "string-util.h"
+ #include "time-util.h"
+ #include "user-util.h"
++#include "missing_stdlib.h"
+
+ #define DEFAULT_MAX_USE_LOWER (uint64_t) (1ULL*1024ULL*1024ULL)           /* 1 MiB */
+ #define DEFAULT_MAX_USE_UPPER (uint64_t) (4ULL*1024ULL*1024ULL*1024ULL)   /* 4 GiB */
+diff --git a/src/fstab-generator/fstab-generator.c b/src/fstab-generator/fstab-generator.c
+index efc553b698..acea922311 100644
+--- a/src/fstab-generator/fstab-generator.c
++++ b/src/fstab-generator/fstab-generator.c
+@@ -33,6 +33,7 @@
+ #include "unit-name.h"
+ #include "virt.h"
+ #include "volatile-util.h"
++#include "missing_stdlib.h"
+
+ typedef enum MountPointFlags {
+         MOUNT_NOAUTO    = 1 << 0,
+diff --git a/src/journal-remote/journal-remote-main.c b/src/journal-remote/journal-remote-main.c
+index 7df264fb53..9463a0e9fb 100644
+--- a/src/journal-remote/journal-remote-main.c
++++ b/src/journal-remote/journal-remote-main.c
+@@ -25,6 +25,7 @@
+ #include "stat-util.h"
+ #include "string-table.h"
+ #include "strv.h"
++#include "missing_stdlib.h"
+
+ #define PRIV_KEY_FILE CERTIFICATE_ROOT "/private/journal-remote.pem"
+ #define CERT_FILE     CERTIFICATE_ROOT "/certs/journal-remote.pem"
+diff --git a/src/journal/journalctl.c b/src/journal/journalctl.c
+index da0fac548e..c1c043e0e0 100644
+--- a/src/journal/journalctl.c
++++ b/src/journal/journalctl.c
+@@ -72,6 +72,7 @@
+ #include "unit-name.h"
+ #include "user-util.h"
+ #include "varlink.h"
++#include "missing_stdlib.h"
+
+ #define DEFAULT_FSS_INTERVAL_USEC (15*USEC_PER_MINUTE)
+ #define PROCESS_INOTIFY_INTERVAL 1024   /* Every 1,024 messages processed */
+diff --git a/src/libsystemd/sd-bus/bus-message.c b/src/libsystemd/sd-bus/bus-message.c
+index 9719f97c02..75decd9834 100644
+--- a/src/libsystemd/sd-bus/bus-message.c
++++ b/src/libsystemd/sd-bus/bus-message.c
+@@ -19,6 +19,7 @@
+ #include "strv.h"
+ #include "time-util.h"
+ #include "utf8.h"
++#include "missing_stdlib.h"
+
+ static int message_append_basic(sd_bus_message *m, char type, const void *p, const void **stored);
+ static int message_parse_fields(sd_bus_message *m);
+diff --git a/src/libsystemd/sd-bus/bus-objects.c b/src/libsystemd/sd-bus/bus-objects.c
+index 2ad7a9993d..bba72f99f4 100644
+--- a/src/libsystemd/sd-bus/bus-objects.c
++++ b/src/libsystemd/sd-bus/bus-objects.c
+@@ -11,6 +11,7 @@
+ #include "missing_capability.h"
+ #include "string-util.h"
+ #include "strv.h"
++#include "missing_stdlib.h"
+
+ static int node_vtable_get_userdata(
+                 sd_bus *bus,
+diff --git a/src/libsystemd/sd-bus/bus-socket.c b/src/libsystemd/sd-bus/bus-socket.c
+index 64037e4fe0..9b9ce0aaa9 100644
+--- a/src/libsystemd/sd-bus/bus-socket.c
++++ b/src/libsystemd/sd-bus/bus-socket.c
+@@ -27,6 +27,7 @@
+ #include "string-util.h"
+ #include "user-util.h"
+ #include "utf8.h"
++#include "missing_stdlib.h"
+
+ #define SNDBUF_SIZE (8*1024*1024)
+
+diff --git a/src/libsystemd/sd-bus/sd-bus.c b/src/libsystemd/sd-bus/sd-bus.c
+index f6a5e4aa06..b36faa79a3 100644
+--- a/src/libsystemd/sd-bus/sd-bus.c
++++ b/src/libsystemd/sd-bus/sd-bus.c
+@@ -44,6 +44,7 @@
+ #include "string-util.h"
+ #include "strv.h"
+ #include "user-util.h"
++#include "missing_stdlib.h"
+
+ #define log_debug_bus_message(m)                                         \
+         do {                                                             \
+diff --git a/src/libsystemd/sd-bus/test-bus-benchmark.c b/src/libsystemd/sd-bus/test-bus-benchmark.c
+index 1eb6edd329..d434a3c178 100644
+--- a/src/libsystemd/sd-bus/test-bus-benchmark.c
++++ b/src/libsystemd/sd-bus/test-bus-benchmark.c
+@@ -13,6 +13,7 @@
+ #include "missing_resource.h"
+ #include "string-util.h"
+ #include "time-util.h"
++#include "missing_stdlib.h"
+
+ #define MAX_SIZE (2*1024*1024)
+
+diff --git a/src/libsystemd/sd-journal/sd-journal.c b/src/libsystemd/sd-journal/sd-journal.c
+index 9947947ef2..8dc6f93159 100644
+--- a/src/libsystemd/sd-journal/sd-journal.c
++++ b/src/libsystemd/sd-journal/sd-journal.c
+@@ -41,6 +41,7 @@
+ #include "string-util.h"
+ #include "strv.h"
+ #include "syslog-util.h"
++#include "missing_stdlib.h"
+
+ #define JOURNAL_FILES_RECHECK_USEC (2 * USEC_PER_SEC)
+
+diff --git a/src/login/pam_systemd.c b/src/login/pam_systemd.c
+index ba2fca32c6..e1f9caa13b 100644
+--- a/src/login/pam_systemd.c
++++ b/src/login/pam_systemd.c
+@@ -32,6 +32,7 @@
+ #include "locale-util.h"
+ #include "login-util.h"
+ #include "macro.h"
++#include "missing_stdlib.h"
+ #include "pam-util.h"
+ #include "parse-util.h"
+ #include "path-util.h"
+diff --git a/src/network/generator/network-generator.c b/src/network/generator/network-generator.c
+index 1090934bfc..69a77f66e2 100644
+--- a/src/network/generator/network-generator.c
++++ b/src/network/generator/network-generator.c
+@@ -13,6 +13,7 @@
+ #include "string-table.h"
+ #include "string-util.h"
+ #include "strv.h"
++#include "missing_stdlib.h"
+
+ /*
+   # .network
+diff --git a/src/nspawn/nspawn-settings.c b/src/nspawn/nspawn-settings.c
+index 05bde1c756..aa29587868 100644
+--- a/src/nspawn/nspawn-settings.c
++++ b/src/nspawn/nspawn-settings.c
+@@ -16,6 +16,7 @@
+ #include "string-util.h"
+ #include "strv.h"
+ #include "user-util.h"
++#include "missing_stdlib.h"
+
+ Settings *settings_new(void) {
+         Settings *s;
+diff --git a/src/nss-mymachines/nss-mymachines.c b/src/nss-mymachines/nss-mymachines.c
+index c64e79bdff..eda26b0b9a 100644
+--- a/src/nss-mymachines/nss-mymachines.c
++++ b/src/nss-mymachines/nss-mymachines.c
+@@ -21,6 +21,7 @@
+ #include "nss-util.h"
+ #include "signal-util.h"
+ #include "string-util.h"
++#include "missing_stdlib.h"
+
+ static void setup_logging_once(void) {
+         static pthread_once_t once = PTHREAD_ONCE_INIT;
+diff --git a/src/portable/portable.c b/src/portable/portable.c
+index 7811833fac..c6414da91c 100644
+--- a/src/portable/portable.c
++++ b/src/portable/portable.c
+@@ -39,6 +39,7 @@
+ #include "strv.h"
+ #include "tmpfile-util.h"
+ #include "user-util.h"
++#include "missing_stdlib.h"
+
+ /* Markers used in the first line of our 20-portable.conf unit file drop-in to determine, that a) the unit file was
+  * dropped there by the portable service logic and b) for which image it was dropped there. */
+diff --git a/src/resolve/resolvectl.c b/src/resolve/resolvectl.c
+index 2638e985fb..82c903fd66 100644
+--- a/src/resolve/resolvectl.c
++++ b/src/resolve/resolvectl.c
+@@ -48,6 +48,7 @@
+ #include "varlink.h"
+ #include "verb-log-control.h"
+ #include "verbs.h"
++#include "missing_stdlib.h"
+
+ static int arg_family = AF_UNSPEC;
+ static int arg_ifindex = 0;
+diff --git a/src/shared/bus-get-properties.c b/src/shared/bus-get-properties.c
+index 8b4f66b22e..5926e4c61b 100644
+--- a/src/shared/bus-get-properties.c
++++ b/src/shared/bus-get-properties.c
+@@ -4,6 +4,7 @@
+ #include "rlimit-util.h"
+ #include "stdio-util.h"
+ #include "string-util.h"
++#include "missing_stdlib.h"
+
+ int bus_property_get_bool(
+                 sd_bus *bus,
+diff --git a/src/shared/bus-unit-procs.c b/src/shared/bus-unit-procs.c
+index 8b462b5627..183ce1c18e 100644
+--- a/src/shared/bus-unit-procs.c
++++ b/src/shared/bus-unit-procs.c
+@@ -11,6 +11,7 @@
+ #include "sort-util.h"
+ #include "string-util.h"
+ #include "terminal-util.h"
++#include "missing_stdlib.h"
+
+ struct CGroupInfo {
+         char *cgroup_path;
+diff --git a/src/shared/bus-unit-util.c b/src/shared/bus-unit-util.c
+index 1e95e36678..640ee031d5 100644
+--- a/src/shared/bus-unit-util.c
++++ b/src/shared/bus-unit-util.c
+@@ -50,6 +50,7 @@
+ #include "unit-def.h"
+ #include "user-util.h"
+ #include "utf8.h"
++#include "missing_stdlib.h"
+
+ int bus_parse_unit_info(sd_bus_message *message, UnitInfo *u) {
+         assert(message);
+diff --git a/src/shared/bus-util.c b/src/shared/bus-util.c
+index d09ec5148d..f38a8f7cc1 100644
+--- a/src/shared/bus-util.c
++++ b/src/shared/bus-util.c
+@@ -21,6 +21,7 @@
+ #include "path-util.h"
+ #include "socket-util.h"
+ #include "stdio-util.h"
++#include "missing_stdlib.h"
+
+ static int name_owner_change_callback(sd_bus_message *m, void *userdata, sd_bus_error *ret_error) {
+         sd_event *e = ASSERT_PTR(userdata);
+diff --git a/src/shared/dns-domain.c b/src/shared/dns-domain.c
+index 620b156563..5ee5b09186 100644
+--- a/src/shared/dns-domain.c
++++ b/src/shared/dns-domain.c
+@@ -18,6 +18,7 @@
+ #include "string-util.h"
+ #include "strv.h"
+ #include "utf8.h"
++#include "missing_stdlib.h"
+
+ int dns_label_unescape(const char **name, char *dest, size_t sz, DNSLabelFlags flags) {
+         const char *n;
+diff --git a/src/shared/journal-importer.c b/src/shared/journal-importer.c
+index d9eabec886..534c6cf7e3 100644
+--- a/src/shared/journal-importer.c
++++ b/src/shared/journal-importer.c
+@@ -15,6 +15,7 @@
+ #include "parse-util.h"
+ #include "string-util.h"
+ #include "unaligned.h"
++#include "missing_stdlib.h"
+
+ enum {
+         IMPORTER_STATE_LINE = 0,    /* waiting to read, or reading line */
+diff --git a/src/shared/logs-show.c b/src/shared/logs-show.c
+index b72e516c8d..6e832b74c3 100644
+--- a/src/shared/logs-show.c
++++ b/src/shared/logs-show.c
+@@ -41,6 +41,7 @@
+ #include "time-util.h"
+ #include "utf8.h"
+ #include "web-util.h"
++#include "missing_stdlib.h"
+
+ /* up to three lines (each up to 100 characters) or 300 characters, whichever is less */
+ #define PRINT_LINE_THRESHOLD 3
+diff --git a/src/shared/pager.c b/src/shared/pager.c
+index 6ed35a3ca9..99d9d36140 100644
+--- a/src/shared/pager.c
++++ b/src/shared/pager.c
+@@ -25,6 +25,7 @@
+ #include "string-util.h"
+ #include "strv.h"
+ #include "terminal-util.h"
++#include "missing_stdlib.h"
+
+ static pid_t pager_pid = 0;
+
+diff --git a/src/socket-proxy/socket-proxyd.c b/src/socket-proxy/socket-proxyd.c
+index 821049e667..08a5bdae3d 100644
+--- a/src/socket-proxy/socket-proxyd.c
++++ b/src/socket-proxy/socket-proxyd.c
+@@ -26,6 +26,7 @@
+ #include "set.h"
+ #include "socket-util.h"
+ #include "string-util.h"
++#include "missing_stdlib.h"
+
+ #define BUFFER_SIZE (256 * 1024)
+
+diff --git a/src/test/test-hexdecoct.c b/src/test/test-hexdecoct.c
+index 9d71db6ae1..a9938c1e6e 100644
+--- a/src/test/test-hexdecoct.c
++++ b/src/test/test-hexdecoct.c
+@@ -7,6 +7,7 @@
+ #include "macro.h"
+ #include "random-util.h"
+ #include "string-util.h"
++#include "missing_stdlib.h"
+ #include "tests.h"
+
+ TEST(hexchar) {
+diff --git a/src/udev/udev-builtin-path_id.c b/src/udev/udev-builtin-path_id.c
+index 8e4d57ee72..6b4555b4d5 100644
+--- a/src/udev/udev-builtin-path_id.c
++++ b/src/udev/udev-builtin-path_id.c
+@@ -22,6 +22,7 @@
+ #include "sysexits.h"
+ #include "udev-builtin.h"
+ #include "udev-util.h"
++#include "missing_stdlib.h"
+
+ _printf_(2,3)
+ static void path_prepend(char **path, const char *fmt, ...) {
+diff --git a/src/udev/udev-event.c b/src/udev/udev-event.c
+index ec4ad30824..bc40303a46 100644
+--- a/src/udev/udev-event.c
++++ b/src/udev/udev-event.c
+@@ -34,6 +34,7 @@
+ #include "udev-util.h"
+ #include "udev-watch.h"
+ #include "user-util.h"
++#include "missing_stdlib.h"
+
+ typedef struct Spawn {
+         sd_device *device;
+diff --git a/src/udev/udev-rules.c b/src/udev/udev-rules.c
+index 5bd09a64d1..0ce79f815c 100644
+--- a/src/udev/udev-rules.c
++++ b/src/udev/udev-rules.c
+@@ -34,6 +34,7 @@
+ #include "udev-util.h"
+ #include "user-util.h"
+ #include "virt.h"
++#include "missing_stdlib.h"
+
+ #define RULES_DIRS (const char* const*) CONF_PATHS_STRV("udev/rules.d")
+
+--
+2.39.2

--- a/sd-measure/patches/0012-don-t-fail-if-GLOB_BRACE-and-GLOB_ALTDIRFUNC-is-not-.patch
+++ b/sd-measure/patches/0012-don-t-fail-if-GLOB_BRACE-and-GLOB_ALTDIRFUNC-is-not-.patch
@@ -1,0 +1,154 @@
+From 747ff78ecda6afe01c7eab4d7c27aea6af810c86 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Mon, 25 Feb 2019 14:56:21 +0800
+Subject: [PATCH] don't fail if GLOB_BRACE and GLOB_ALTDIRFUNC is not defined
+
+If the standard library doesn't provide brace
+expansion users just won't get it.
+
+Dont use GNU GLOB extentions on non-glibc systems
+
+Conditionalize use of GLOB_ALTDIRFUNC
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[rebased for systemd 243]
+Signed-off-by: Scott Murray <scott.murray@konsulko.com>
+---
+ src/basic/glob-util.c     | 12 ++++++++++++
+ src/test/test-glob-util.c | 16 ++++++++++++++++
+ src/tmpfiles/tmpfiles.c   | 10 ++++++++++
+ 3 files changed, 38 insertions(+)
+
+diff --git a/src/basic/glob-util.c b/src/basic/glob-util.c
+index fd60a6eda2..c73edc41ea 100644
+--- a/src/basic/glob-util.c
++++ b/src/basic/glob-util.c
+@@ -12,6 +12,12 @@
+ #include "path-util.h"
+ #include "strv.h"
+
++/* Don't fail if the standard library
++ * doesn't provide brace expansion */
++#ifndef GLOB_BRACE
++#define GLOB_BRACE 0
++#endif
++
+ static void closedir_wrapper(void* v) {
+         (void) closedir(v);
+ }
+@@ -19,6 +25,7 @@ static void closedir_wrapper(void* v) {
+ int safe_glob(const char *path, int flags, glob_t *pglob) {
+         int k;
+
++#ifdef GLOB_ALTDIRFUNC
+         /* We want to set GLOB_ALTDIRFUNC ourselves, don't allow it to be set. */
+         assert(!(flags & GLOB_ALTDIRFUNC));
+
+@@ -32,9 +39,14 @@ int safe_glob(const char *path, int flags, glob_t *pglob) {
+                 pglob->gl_lstat = lstat;
+         if (!pglob->gl_stat)
+                 pglob->gl_stat = stat;
++#endif
+
+         errno = 0;
++#ifdef GLOB_ALTDIRFUNC
+         k = glob(path, flags | GLOB_ALTDIRFUNC, NULL, pglob);
++#else
++        k = glob(path, flags, NULL, pglob);
++#endif
+         if (k == GLOB_NOMATCH)
+                 return -ENOENT;
+         if (k == GLOB_NOSPACE)
+diff --git a/src/test/test-glob-util.c b/src/test/test-glob-util.c
+index 9b3e73cce0..3790ba3be5 100644
+--- a/src/test/test-glob-util.c
++++ b/src/test/test-glob-util.c
+@@ -34,6 +34,12 @@ TEST(glob_first) {
+         assert_se(first == NULL);
+ }
+
++/* Don't fail if the standard library
++ * doesn't provide brace expansion */
++#ifndef GLOB_BRACE
++#define GLOB_BRACE 0
++#endif
++
+ TEST(glob_exists) {
+         char name[] = "/tmp/test-glob_exists.XXXXXX";
+         int fd = -EBADF;
+@@ -61,11 +67,13 @@ TEST(glob_no_dot) {
+         const char *fn;
+
+         _cleanup_globfree_ glob_t g = {
++#ifdef GLOB_ALTDIRFUNC
+                 .gl_closedir = closedir_wrapper,
+                 .gl_readdir = (struct dirent *(*)(void *)) readdir_no_dot,
+                 .gl_opendir = (void *(*)(const char *)) opendir,
+                 .gl_lstat = lstat,
+                 .gl_stat = stat,
++#endif
+         };
+
+         int r;
+@@ -73,11 +81,19 @@ TEST(glob_no_dot) {
+         assert_se(mkdtemp(template));
+
+         fn = strjoina(template, "/*");
++#ifdef GLOB_ALTDIRFUNC
+         r = glob(fn, GLOB_NOSORT|GLOB_BRACE|GLOB_ALTDIRFUNC, NULL, &g);
++#else
++        r = glob(fn, GLOB_NOSORT|GLOB_BRACE, NULL, &g);
++#endif
+         assert_se(r == GLOB_NOMATCH);
+
+         fn = strjoina(template, "/.*");
++#ifdef GLOB_ALTDIRFUNC
+         r = glob(fn, GLOB_NOSORT|GLOB_BRACE|GLOB_ALTDIRFUNC, NULL, &g);
++#else
++        r = glob(fn, GLOB_NOSORT|GLOB_BRACE, NULL, &g);
++#endif
+         assert_se(r == GLOB_NOMATCH);
+
+         (void) rm_rf(template, REMOVE_ROOT|REMOVE_PHYSICAL);
+diff --git a/src/tmpfiles/tmpfiles.c b/src/tmpfiles/tmpfiles.c
+index 458aed7054..2cf24b38c0 100644
+--- a/src/tmpfiles/tmpfiles.c
++++ b/src/tmpfiles/tmpfiles.c
+@@ -73,6 +73,12 @@
+ #include "user-util.h"
+ #include "virt.h"
+
++/* Don't fail if the standard library
++ * doesn't provide brace expansion */
++#ifndef GLOB_BRACE
++#define GLOB_BRACE 0
++#endif
++
+ /* This reads all files listed in /etc/tmpfiles.d/?*.conf and creates
+  * them in the file system. This is intended to be used to create
+  * properly owned directories beneath /tmp, /var/tmp, /run, which are
+@@ -2194,7 +2200,9 @@ finish:
+
+ static int glob_item(Item *i, action_t action) {
+         _cleanup_globfree_ glob_t g = {
++#ifdef GLOB_ALTDIRFUNC
+                 .gl_opendir = (void *(*)(const char *)) opendir_nomod,
++#endif
+         };
+         int r = 0, k;
+
+@@ -2214,7 +2222,9 @@ static int glob_item(Item *i, action_t action) {
+
+ static int glob_item_recursively(Item *i, fdaction_t action) {
+         _cleanup_globfree_ glob_t g = {
++#ifdef GLOB_ALTDIRFUNC
+                 .gl_opendir = (void *(*)(const char *)) opendir_nomod,
++#endif
+         };
+         int r = 0, k;
+
+--
+2.39.2

--- a/sd-measure/patches/0013-add-missing-FTW_-macros-for-musl.patch
+++ b/sd-measure/patches/0013-add-missing-FTW_-macros-for-musl.patch
@@ -1,0 +1,43 @@
+From efd7b41cf270c7b07ee3b9aec0fedd8e52dd422f Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Mon, 25 Feb 2019 15:00:06 +0800
+Subject: [PATCH] add missing FTW_ macros for musl
+
+This is to avoid build failures like below for musl.
+
+  locale-util.c:296:24: error: 'FTW_STOP' undeclared
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ src/basic/missing_type.h    | 4 ++++
+ src/test/test-recurse-dir.c | 1 +
+ 2 files changed, 5 insertions(+)
+
+diff --git a/src/basic/missing_type.h b/src/basic/missing_type.h
+index 6c0456349d..73a5b90e3c 100644
+--- a/src/basic/missing_type.h
++++ b/src/basic/missing_type.h
+@@ -14,3 +14,7 @@
+ #ifndef __GLIBC__
+ typedef int (*comparison_fn_t)(const void *, const void *);
+ #endif
++
++#ifndef FTW_CONTINUE
++#define FTW_CONTINUE 0
++#endif
+diff --git a/src/test/test-recurse-dir.c b/src/test/test-recurse-dir.c
+index 2c2120b136..bc60a178a2 100644
+--- a/src/test/test-recurse-dir.c
++++ b/src/test/test-recurse-dir.c
+@@ -6,6 +6,7 @@
+ #include "recurse-dir.h"
+ #include "strv.h"
+ #include "tests.h"
++#include "missing_type.h"
+
+ static char **list_nftw = NULL;
+
+--
+2.39.2

--- a/sd-measure/patches/0014-Use-uintmax_t-for-handling-rlim_t.patch
+++ b/sd-measure/patches/0014-Use-uintmax_t-for-handling-rlim_t.patch
@@ -1,0 +1,105 @@
+From 60f7d2c62bc3718023df93c01688d3ee1625d64d Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Mon, 25 Feb 2019 15:12:41 +0800
+Subject: [PATCH] Use uintmax_t for handling rlim_t
+
+PRIu{32,64} is not right format to represent rlim_t type
+therefore use %ju and typecast the rlim_t variables to
+uintmax_t.
+
+Fixes portablility errors like
+
+execute.c:3446:36: error: format '%lu' expects argument of type 'long unsigned int', but argument 5 has type 'rlim_t {aka long long unsigned int}' [-Werror=format=]
+|                          fprintf(f, "%s%s: " RLIM_FMT "\n",
+|                                     ^~~~~~~~
+|                                  prefix, rlimit_to_string(i), c->rlimit[i]->rlim_max);
+|                                                               ~~~~~~~~~~~~~~~~~~~~~~
+
+Upstream-Status: Denied [https://github.com/systemd/systemd/pull/7199]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+[Rebased for v241]
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ src/basic/format-util.h |  8 +-------
+ src/basic/rlimit-util.c | 12 ++++++------
+ src/core/execute.c      |  4 ++--
+ 3 files changed, 9 insertions(+), 15 deletions(-)
+
+diff --git a/src/basic/format-util.h b/src/basic/format-util.h
+index 8719df3e29..9becc96066 100644
+--- a/src/basic/format-util.h
++++ b/src/basic/format-util.h
+@@ -34,13 +34,7 @@ assert_cc(sizeof(gid_t) == sizeof(uint32_t));
+ #  error Unknown timex member size
+ #endif
+
+-#if SIZEOF_RLIM_T == 8
+-#  define RLIM_FMT "%" PRIu64
+-#elif SIZEOF_RLIM_T == 4
+-#  define RLIM_FMT "%" PRIu32
+-#else
+-#  error Unknown rlim_t size
+-#endif
++#define RLIM_FMT "%ju"
+
+ #if SIZEOF_DEV_T == 8
+ #  define DEV_FMT "%" PRIu64
+diff --git a/src/basic/rlimit-util.c b/src/basic/rlimit-util.c
+index 33dfde9d6c..e018fd81fd 100644
+--- a/src/basic/rlimit-util.c
++++ b/src/basic/rlimit-util.c
+@@ -44,7 +44,7 @@ int setrlimit_closest(int resource, const struct rlimit *rlim) {
+             fixed.rlim_max == highest.rlim_max)
+                 return 0;
+
+-        log_debug("Failed at setting rlimit " RLIM_FMT " for resource RLIMIT_%s. Will attempt setting value " RLIM_FMT " instead.", rlim->rlim_max, rlimit_to_string(resource), fixed.rlim_max);
++        log_debug("Failed at setting rlimit " RLIM_FMT " for resource RLIMIT_%s. Will attempt setting value " RLIM_FMT " instead.", (uintmax_t)rlim->rlim_max, rlimit_to_string(resource), (uintmax_t)fixed.rlim_max);
+
+         return RET_NERRNO(setrlimit(resource, &fixed));
+ }
+@@ -307,13 +307,13 @@ int rlimit_format(const struct rlimit *rl, char **ret) {
+         if (rl->rlim_cur >= RLIM_INFINITY && rl->rlim_max >= RLIM_INFINITY)
+                 r = free_and_strdup(&s, "infinity");
+         else if (rl->rlim_cur >= RLIM_INFINITY)
+-                r = asprintf(&s, "infinity:" RLIM_FMT, rl->rlim_max);
++                r = asprintf(&s, "infinity:" RLIM_FMT, (uintmax_t)rl->rlim_max);
+         else if (rl->rlim_max >= RLIM_INFINITY)
+-                r = asprintf(&s, RLIM_FMT ":infinity", rl->rlim_cur);
++                r = asprintf(&s, RLIM_FMT ":infinity", (uintmax_t)rl->rlim_cur);
+         else if (rl->rlim_cur == rl->rlim_max)
+-                r = asprintf(&s, RLIM_FMT, rl->rlim_cur);
++                r = asprintf(&s, RLIM_FMT, (uintmax_t)rl->rlim_cur);
+         else
+-                r = asprintf(&s, RLIM_FMT ":" RLIM_FMT, rl->rlim_cur, rl->rlim_max);
++                r = asprintf(&s, RLIM_FMT ":" RLIM_FMT, (uintmax_t)rl->rlim_cur, (uintmax_t)rl->rlim_max);
+         if (r < 0)
+                 return -ENOMEM;
+
+@@ -403,7 +403,7 @@ int rlimit_nofile_safe(void) {
+
+         rl.rlim_cur = FD_SETSIZE;
+         if (setrlimit(RLIMIT_NOFILE, &rl) < 0)
+-                return log_debug_errno(errno, "Failed to lower RLIMIT_NOFILE's soft limit to " RLIM_FMT ": %m", rl.rlim_cur);
++                return log_debug_errno(errno, "Failed to lower RLIMIT_NOFILE's soft limit to " RLIM_FMT ": %m", (uintmax_t)rl.rlim_cur);
+
+         return 1;
+ }
+diff --git a/src/core/execute.c b/src/core/execute.c
+index 8ef76de9ab..ea1c203e43 100644
+--- a/src/core/execute.c
++++ b/src/core/execute.c
+@@ -6034,9 +6034,9 @@ void exec_context_dump(const ExecContext *c, FILE* f, const char *prefix) {
+         for (unsigned i = 0; i < RLIM_NLIMITS; i++)
+                 if (c->rlimit[i]) {
+                         fprintf(f, "%sLimit%s: " RLIM_FMT "\n",
+-                                prefix, rlimit_to_string(i), c->rlimit[i]->rlim_max);
++                                prefix, rlimit_to_string(i), (uintmax_t)c->rlimit[i]->rlim_max);
+                         fprintf(f, "%sLimit%sSoft: " RLIM_FMT "\n",
+-                                prefix, rlimit_to_string(i), c->rlimit[i]->rlim_cur);
++                                prefix, rlimit_to_string(i), (uintmax_t)c->rlimit[i]->rlim_cur);
+                 }
+
+         if (c->ioprio_set) {
+--
+2.39.2

--- a/sd-measure/patches/0015-test-sizeof.c-Disable-tests-for-missing-typedefs-in-.patch
+++ b/sd-measure/patches/0015-test-sizeof.c-Disable-tests-for-missing-typedefs-in-.patch
@@ -1,0 +1,40 @@
+From 96088895149746dd2ee8e8c2e4b97972ccf44696 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Wed, 28 Feb 2018 21:25:22 -0800
+Subject: [PATCH] test-sizeof.c: Disable tests for missing typedefs in musl
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ src/test/test-sizeof.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/test/test-sizeof.c b/src/test/test-sizeof.c
+index 55bd81e22f..6cf92bffde 100644
+--- a/src/test/test-sizeof.c
++++ b/src/test/test-sizeof.c
+@@ -55,8 +55,10 @@ int main(void) {
+         info(unsigned);
+         info(unsigned long);
+         info(unsigned long long);
++#ifdef __GLIBC__
+         info(__syscall_ulong_t);
+         info(__syscall_slong_t);
++#endif
+         info(intmax_t);
+         info(uintmax_t);
+
+@@ -76,7 +78,9 @@ int main(void) {
+         info(ssize_t);
+         info(time_t);
+         info(usec_t);
++#ifdef __GLIBC__
+         info(__time_t);
++#endif
+         info(pid_t);
+         info(uid_t);
+         info(gid_t);
+--
+2.39.2

--- a/sd-measure/patches/0016-don-t-pass-AT_SYMLINK_NOFOLLOW-flag-to-faccessat.patch
+++ b/sd-measure/patches/0016-don-t-pass-AT_SYMLINK_NOFOLLOW-flag-to-faccessat.patch
@@ -1,0 +1,98 @@
+From 26b02348e39fe72b73dd61bba8a0cefb0352717d Mon Sep 17 00:00:00 2001
+From: Andre McCurdy <armccurdy@gmail.com>
+Date: Tue, 10 Oct 2017 14:33:30 -0700
+Subject: [PATCH] don't pass AT_SYMLINK_NOFOLLOW flag to faccessat()
+
+Avoid using AT_SYMLINK_NOFOLLOW flag. It doesn't seem like the right
+thing to do and it's not portable (not supported by musl). See:
+
+  http://lists.landley.net/pipermail/toybox-landley.net/2014-September/003610.html
+  http://www.openwall.com/lists/musl/2015/02/05/2
+
+Note that laccess() is never passing AT_EACCESS so a lot of the
+discussion in the links above doesn't apply. Note also that
+(currently) all systemd callers of laccess() pass mode as F_OK, so
+only check for existence of a file, not access permissions.
+Therefore, in this case, the only distiction between faccessat()
+with (flag == 0) and (flag == AT_SYMLINK_NOFOLLOW) is the behaviour
+for broken symlinks; laccess() on a broken symlink will succeed with
+(flag == AT_SYMLINK_NOFOLLOW) and fail (flag == 0).
+
+The laccess() macros was added to systemd some time ago and it's not
+clear if or why it needs to return success for broken symlinks. Maybe
+just historical and not actually necessary or desired behaviour?
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
+---
+ src/basic/fs-util.h          | 21 ++++++++++++++++++++-
+ src/shared/base-filesystem.c |  6 +++---
+ 2 files changed, 23 insertions(+), 4 deletions(-)
+
+diff --git a/src/basic/fs-util.h b/src/basic/fs-util.h
+index 932d003f19..33215dbf5f 100644
+--- a/src/basic/fs-util.h
++++ b/src/basic/fs-util.h
+@@ -50,8 +50,27 @@ int futimens_opath(int fd, const struct timespec ts[2]);
+ int fd_warn_permissions(const char *path, int fd);
+ int stat_warn_permissions(const char *path, const struct stat *st);
+
++/*
++   Avoid using AT_SYMLINK_NOFOLLOW flag. It doesn't seem like the right thing to
++   do and it's not portable (not supported by musl). See:
++
++     http://lists.landley.net/pipermail/toybox-landley.net/2014-September/003610.html
++     http://www.openwall.com/lists/musl/2015/02/05/2
++
++   Note that laccess() is never passing AT_EACCESS so a lot of the discussion in
++   the links above doesn't apply. Note also that (currently) all systemd callers
++   of laccess() pass mode as F_OK, so only check for existence of a file, not
++   access permissions. Therefore, in this case, the only distiction between
++   faccessat() with (flag == 0) and (flag == AT_SYMLINK_NOFOLLOW) is the
++   behaviour for broken symlinks; laccess() on a broken symlink will succeed
++   with (flag == AT_SYMLINK_NOFOLLOW) and fail (flag == 0).
++
++   The laccess() macros was added to systemd some time ago and it's not clear if
++   or why it needs to return success for broken symlinks. Maybe just historical
++   and not actually necessary or desired behaviour?
++*/
+ #define laccess(path, mode)                                             \
+-        RET_NERRNO(faccessat(AT_FDCWD, (path), (mode), AT_SYMLINK_NOFOLLOW))
++        RET_NERRNO(faccessat(AT_FDCWD, (path), (mode), 0))
+
+ int touch_file(const char *path, bool parents, usec_t stamp, uid_t uid, gid_t gid, mode_t mode);
+
+diff --git a/src/shared/base-filesystem.c b/src/shared/base-filesystem.c
+index be6dd1654a..2726dc946a 100644
+--- a/src/shared/base-filesystem.c
++++ b/src/shared/base-filesystem.c
+@@ -131,7 +131,7 @@ int base_filesystem_create(const char *root, uid_t uid, gid_t gid) {
+                 return log_error_errno(errno, "Failed to open root file system: %m");
+
+         for (size_t i = 0; i < ELEMENTSOF(table); i++) {
+-                if (faccessat(fd, table[i].dir, F_OK, AT_SYMLINK_NOFOLLOW) >= 0)
++                if (faccessat(fd, table[i].dir, F_OK, 0) >= 0)
+                         continue;
+
+                 if (table[i].target) {
+@@ -139,7 +139,7 @@ int base_filesystem_create(const char *root, uid_t uid, gid_t gid) {
+
+                         /* check if one of the targets exists */
+                         NULSTR_FOREACH(s, table[i].target) {
+-                                if (faccessat(fd, s, F_OK, AT_SYMLINK_NOFOLLOW) < 0)
++                                if (faccessat(fd, s, F_OK, 0) < 0)
+                                         continue;
+
+                                 /* check if a specific file exists at the target path */
+@@ -150,7 +150,7 @@ int base_filesystem_create(const char *root, uid_t uid, gid_t gid) {
+                                         if (!p)
+                                                 return log_oom();
+
+-                                        if (faccessat(fd, p, F_OK, AT_SYMLINK_NOFOLLOW) < 0)
++                                        if (faccessat(fd, p, F_OK, 0) < 0)
+                                                 continue;
+                                 }
+
+--
+2.39.2

--- a/sd-measure/patches/0017-Define-glibc-compatible-basename-for-non-glibc-syste.patch
+++ b/sd-measure/patches/0017-Define-glibc-compatible-basename-for-non-glibc-syste.patch
@@ -1,0 +1,33 @@
+From fdc7fb940bb41020271b9db41d5608004efdbde5 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sun, 27 May 2018 08:36:44 -0700
+Subject: [PATCH] Define glibc compatible basename() for non-glibc systems
+
+Fixes builds with musl, even though systemd is adamant about
+using non-posix basename implementation, we have a way out
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/machine/machine-dbus.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/machine/machine-dbus.c b/src/machine/machine-dbus.c
+index 45bc056326..aee51d5da5 100644
+--- a/src/machine/machine-dbus.c
++++ b/src/machine/machine-dbus.c
+@@ -4,6 +4,11 @@
+ #include <sys/mount.h>
+ #include <sys/wait.h>
+
++#if !defined(__GLIBC__)
++#include <string.h>
++#define basename(src) (strrchr(src,'/') ? strrchr(src,'/')+1 : src)
++#endif
++
+ #include "alloc-util.h"
+ #include "bus-common-errors.h"
+ #include "bus-get-properties.h"
+--
+2.39.2

--- a/sd-measure/patches/0018-Do-not-disable-buffering-when-writing-to-oom_score_a.patch
+++ b/sd-measure/patches/0018-Do-not-disable-buffering-when-writing-to-oom_score_a.patch
@@ -1,0 +1,40 @@
+From 32fd0dc67b6df531f0769dbb099dbe8f30c28514 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Wed, 4 Jul 2018 15:00:44 +0800
+Subject: [PATCH] Do not disable buffering when writing to oom_score_adj
+
+On musl, disabling buffering when writing to oom_score_adj will
+cause the following error.
+
+  Failed to adjust OOM setting: Invalid argument
+
+This error appears for systemd-udevd.service and dbus.service.
+This is because kernel receives '-' instead of the whole '-900'
+if buffering is disabled.
+
+This is libc implementation specific, as glibc does not have this issue.
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[rebased for systemd 243]
+Signed-off-by: Scott Murray <scott.murray@konsulko.com>
+---
+ src/basic/process-util.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/basic/process-util.c b/src/basic/process-util.c
+index 0747c14c1c..8d0c5aae92 100644
+--- a/src/basic/process-util.c
++++ b/src/basic/process-util.c
+@@ -1405,7 +1405,7 @@ int set_oom_score_adjust(int value) {
+         xsprintf(t, "%i", value);
+
+         return write_string_file("/proc/self/oom_score_adj", t,
+-                                 WRITE_STRING_FILE_VERIFY_ON_FAILURE|WRITE_STRING_FILE_DISABLE_BUFFER);
++                                 WRITE_STRING_FILE_VERIFY_ON_FAILURE);
+ }
+
+ int get_oom_score_adjust(int *ret) {
+--
+2.39.2

--- a/sd-measure/patches/0019-distinguish-XSI-compliant-strerror_r-from-GNU-specif.patch
+++ b/sd-measure/patches/0019-distinguish-XSI-compliant-strerror_r-from-GNU-specif.patch
@@ -1,0 +1,76 @@
+From ed46afcbc6bc1f6277a0a54c3db8cf1b056bca1e Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Tue, 10 Jul 2018 15:40:17 +0800
+Subject: [PATCH] distinguish XSI-compliant strerror_r from GNU-specifi
+ strerror_r
+
+XSI-compliant strerror_r and GNU-specifi strerror_r are different.
+
+       int strerror_r(int errnum, char *buf, size_t buflen);
+                   /* XSI-compliant */
+
+       char *strerror_r(int errnum, char *buf, size_t buflen);
+                   /* GNU-specific */
+
+We need to distinguish between them. Otherwise, we'll get an int value
+assigned to (char *) variable, resulting in segment fault.
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ src/libsystemd/sd-bus/bus-error.c        | 11 ++++++++++-
+ src/libsystemd/sd-journal/journal-send.c |  5 +++++
+ 2 files changed, 15 insertions(+), 1 deletion(-)
+
+diff --git a/src/libsystemd/sd-bus/bus-error.c b/src/libsystemd/sd-bus/bus-error.c
+index 413e2dd43f..805e5da0c0 100644
+--- a/src/libsystemd/sd-bus/bus-error.c
++++ b/src/libsystemd/sd-bus/bus-error.c
+@@ -408,7 +408,12 @@ static void bus_error_strerror(sd_bus_error *e, int error) {
+                         return;
+ 
+                 errno = 0;
++#ifndef __GLIBC__
++                strerror_r(error, m, k);
++                x = m;
++#else
+                 x = strerror_r(error, m, k);
++#endif
+                 if (errno == ERANGE || strlen(x) >= k - 1) {
+                         free(m);
+                         k *= 2;
+@@ -593,8 +598,12 @@ const char* _bus_error_message(const sd_bus_error *e, int error, char buf[static
+ 
+         if (e && e->message)
+                 return e->message;
+-
++#ifndef __GLIBC__
++        strerror_r(abs(error), buf, ERRNO_BUF_LEN);
++        return buf;
++#else
+         return strerror_r(abs(error), buf, ERRNO_BUF_LEN);
++#endif
+ }
+ 
+ static bool map_ok(const sd_bus_error_map *map) {
+diff --git a/src/libsystemd/sd-journal/journal-send.c b/src/libsystemd/sd-journal/journal-send.c
+index 136ebcb153..8a75ba4ecd 100644
+--- a/src/libsystemd/sd-journal/journal-send.c
++++ b/src/libsystemd/sd-journal/journal-send.c
+@@ -381,7 +381,12 @@ static int fill_iovec_perror_and_send(const char *message, int skip, struct iove
+                 char* j;
+ 
+                 errno = 0;
++#ifndef __GLIBC__
++                strerror_r(_saved_errno_, buffer + 8 + k, n - 8 - k);
++                j = buffer + 8 + k;
++#else
+                 j = strerror_r(_saved_errno_, buffer + 8 + k, n - 8 - k);
++#endif
+                 if (errno == 0) {
+                         char error[STRLEN("ERRNO=") + DECIMAL_STR_MAX(int) + 1];
+ 
+-- 
+2.39.2
+

--- a/sd-measure/patches/0020-avoid-redefinition-of-prctl_mm_map-structure.patch
+++ b/sd-measure/patches/0020-avoid-redefinition-of-prctl_mm_map-structure.patch
@@ -1,0 +1,32 @@
+From 277b680d07a178b8278862b60417052d05c1376f Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Mon, 25 Feb 2019 15:44:54 +0800
+Subject: [PATCH] avoid redefinition of prctl_mm_map structure
+
+Fix the following compile failure:
+error: redefinition of 'struct prctl_mm_map'
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+---
+ src/basic/missing_prctl.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/basic/missing_prctl.h b/src/basic/missing_prctl.h
+index ab851306ba..5547cad875 100644
+--- a/src/basic/missing_prctl.h
++++ b/src/basic/missing_prctl.h
+@@ -1,7 +1,9 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ #pragma once
+ 
++#ifdef __GLIBC__
+ #include <linux/prctl.h>
++#endif
+ 
+ /* 58319057b7847667f0c9585b9de0e8932b0fdb08 (4.3) */
+ #ifndef PR_CAP_AMBIENT
+-- 
+2.39.2
+

--- a/sd-measure/patches/0021-do-not-disable-buffer-in-writing-files.patch
+++ b/sd-measure/patches/0021-do-not-disable-buffer-in-writing-files.patch
@@ -1,0 +1,447 @@
+From aa6e5588e6d01c12e2f101d140cc710ab199df16 Mon Sep 17 00:00:00 2001
+From: Chen Qi <Qi.Chen@windriver.com>
+Date: Fri, 1 Mar 2019 15:22:15 +0800
+Subject: [PATCH] do not disable buffer in writing files
+
+Do not disable buffer in writing files, otherwise we get
+failure at boot for musl like below.
+
+  [!!!!!!] Failed to allocate manager object.
+
+And there will be other failures, critical or not critical.
+This is specific to musl.
+
+Upstream-Status: Inappropriate [musl]
+
+Signed-off-by: Chen Qi <Qi.Chen@windriver.com>
+[Rebased for v242]
+Signed-off-by: Andrej Valek <andrej.valek@siemens.com>
+[rebased for systemd 243]
+Signed-off-by: Scott Murray <scott.murray@konsulko.com>
+---
+ src/basic/cgroup-util.c                 | 12 ++++++------
+ src/basic/namespace-util.c              |  4 ++--
+ src/basic/procfs-util.c                 |  4 ++--
+ src/basic/sysctl-util.c                 |  2 +-
+ src/binfmt/binfmt.c                     |  6 +++---
+ src/core/cgroup.c                       |  2 +-
+ src/core/main.c                         |  2 +-
+ src/core/smack-setup.c                  |  8 ++++----
+ src/hibernate-resume/hibernate-resume.c |  2 +-
+ src/home/homework.c                     |  2 +-
+ src/libsystemd/sd-device/sd-device.c    |  2 +-
+ src/nspawn/nspawn-cgroup.c              |  2 +-
+ src/nspawn/nspawn.c                     |  6 +++---
+ src/shared/binfmt-util.c                |  2 +-
+ src/shared/cgroup-setup.c               |  4 ++--
+ src/shared/coredump-util.c              |  2 +-
+ src/shared/smack-util.c                 |  2 +-
+ src/sleep/sleep.c                       |  8 ++++----
+ src/udev/udev-rules.c                   |  1 -
+ src/vconsole/vconsole-setup.c           |  2 +-
+ 20 files changed, 37 insertions(+), 38 deletions(-)
+
+diff --git a/src/basic/cgroup-util.c b/src/basic/cgroup-util.c
+index 11b4375ed5..7d81a6007f 100644
+--- a/src/basic/cgroup-util.c
++++ b/src/basic/cgroup-util.c
+@@ -399,7 +399,7 @@ int cg_kill_kernel_sigkill(const char *controller, const char *path) {
+         if (r < 0)
+                 return r;
+
+-        r = write_string_file(killfile, "1", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(killfile, "1", 0);
+         if (r < 0)
+                 return r;
+
+@@ -805,7 +805,7 @@ int cg_install_release_agent(const char *controller, const char *agent) {
+
+         sc = strstrip(contents);
+         if (isempty(sc)) {
+-                r = write_string_file(fs, agent, WRITE_STRING_FILE_DISABLE_BUFFER);
++                r = write_string_file(fs, agent, 0);
+                 if (r < 0)
+                         return r;
+         } else if (!path_equal(sc, agent))
+@@ -823,7 +823,7 @@ int cg_install_release_agent(const char *controller, const char *agent) {
+
+         sc = strstrip(contents);
+         if (streq(sc, "0")) {
+-                r = write_string_file(fs, "1", WRITE_STRING_FILE_DISABLE_BUFFER);
++                r = write_string_file(fs, "1", 0);
+                 if (r < 0)
+                         return r;
+
+@@ -850,7 +850,7 @@ int cg_uninstall_release_agent(const char *controller) {
+         if (r < 0)
+                 return r;
+
+-        r = write_string_file(fs, "0", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(fs, "0", 0);
+         if (r < 0)
+                 return r;
+
+@@ -860,7 +860,7 @@ int cg_uninstall_release_agent(const char *controller) {
+         if (r < 0)
+                 return r;
+
+-        r = write_string_file(fs, "", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(fs, "", 0);
+         if (r < 0)
+                 return r;
+
+@@ -1752,7 +1752,7 @@ int cg_set_attribute(const char *controller, const char *path, const char *attri
+         if (r < 0)
+                 return r;
+
+-        return write_string_file(p, value, WRITE_STRING_FILE_DISABLE_BUFFER);
++        return write_string_file(p, value, 0);
+ }
+
+ int cg_get_attribute(const char *controller, const char *path, const char *attribute, char **ret) {
+diff --git a/src/basic/namespace-util.c b/src/basic/namespace-util.c
+index f5c0e04cec..272b920022 100644
+--- a/src/basic/namespace-util.c
++++ b/src/basic/namespace-util.c
+@@ -220,12 +220,12 @@ int userns_acquire(const char *uid_map, const char *gid_map) {
+                 freeze();
+
+         xsprintf(path, "/proc/" PID_FMT "/uid_map", pid);
+-        r = write_string_file(path, uid_map, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(path, uid_map, 0);
+         if (r < 0)
+                 return log_error_errno(r, "Failed to write UID map: %m");
+
+         xsprintf(path, "/proc/" PID_FMT "/gid_map", pid);
+-        r = write_string_file(path, gid_map, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(path, gid_map, 0);
+         if (r < 0)
+                 return log_error_errno(r, "Failed to write GID map: %m");
+
+diff --git a/src/basic/procfs-util.c b/src/basic/procfs-util.c
+index 64a95dd866..12cd16db1c 100644
+--- a/src/basic/procfs-util.c
++++ b/src/basic/procfs-util.c
+@@ -64,13 +64,13 @@ int procfs_tasks_set_limit(uint64_t limit) {
+          * decrease it, as threads-max is the much more relevant sysctl. */
+         if (limit > pid_max-1) {
+                 sprintf(buffer, "%" PRIu64, limit+1); /* Add one, since PID 0 is not a valid PID */
+-                r = write_string_file("/proc/sys/kernel/pid_max", buffer, WRITE_STRING_FILE_DISABLE_BUFFER);
++                r = write_string_file("/proc/sys/kernel/pid_max", buffer, 0);
+                 if (r < 0)
+                         return r;
+         }
+
+         sprintf(buffer, "%" PRIu64, limit);
+-        r = write_string_file("/proc/sys/kernel/threads-max", buffer, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/proc/sys/kernel/threads-max", buffer, 0);
+         if (r < 0) {
+                 uint64_t threads_max;
+
+diff --git a/src/basic/sysctl-util.c b/src/basic/sysctl-util.c
+index b66a6622ae..8d1c93008a 100644
+--- a/src/basic/sysctl-util.c
++++ b/src/basic/sysctl-util.c
+@@ -58,7 +58,7 @@ int sysctl_write(const char *property, const char *value) {
+
+         log_debug("Setting '%s' to '%s'", p, value);
+
+-        return write_string_file(p, value, WRITE_STRING_FILE_VERIFY_ON_FAILURE | WRITE_STRING_FILE_DISABLE_BUFFER | WRITE_STRING_FILE_SUPPRESS_REDUNDANT_VIRTUAL);
++        return write_string_file(p, value, WRITE_STRING_FILE_VERIFY_ON_FAILURE | WRITE_STRING_FILE_SUPPRESS_REDUNDANT_VIRTUAL);
+ }
+
+ int sysctl_writef(const char *property, const char *format, ...) {
+diff --git a/src/binfmt/binfmt.c b/src/binfmt/binfmt.c
+index e1ddf97914..df6e156f19 100644
+--- a/src/binfmt/binfmt.c
++++ b/src/binfmt/binfmt.c
+@@ -30,7 +30,7 @@ static bool arg_unregister = false;
+
+ static int delete_rule(const char *rulename) {
+         const char *fn = strjoina("/proc/sys/fs/binfmt_misc/", rulename);
+-        return write_string_file(fn, "-1", WRITE_STRING_FILE_DISABLE_BUFFER);
++        return write_string_file(fn, "-1", 0);
+ }
+
+ static int apply_rule(const char *filename, unsigned line, const char *rule) {
+@@ -58,7 +58,7 @@ static int apply_rule(const char *filename, unsigned line, const char *rule) {
+         if (r >= 0)
+                 log_debug("%s:%u: Rule '%s' deleted.", filename, line, rulename);
+
+-        r = write_string_file("/proc/sys/fs/binfmt_misc/register", rule, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/proc/sys/fs/binfmt_misc/register", rule, 0);
+         if (r < 0)
+                 return log_error_errno(r, "%s:%u: Failed to add binary format '%s': %m",
+                                        filename, line, rulename);
+@@ -244,7 +244,7 @@ static int run(int argc, char *argv[]) {
+                         return r;
+
+                 /* Flush out all rules */
+-                r = write_string_file("/proc/sys/fs/binfmt_misc/status", "-1", WRITE_STRING_FILE_DISABLE_BUFFER);
++                r = write_string_file("/proc/sys/fs/binfmt_misc/status", "-1", 0);
+                 if (r < 0)
+                         log_warning_errno(r, "Failed to flush binfmt_misc rules, ignoring: %m");
+                 else
+diff --git a/src/core/cgroup.c b/src/core/cgroup.c
+index 4cac3f6a89..bebe2cd120 100644
+--- a/src/core/cgroup.c
++++ b/src/core/cgroup.c
+@@ -4267,7 +4267,7 @@ int unit_cgroup_freezer_action(Unit *u, FreezerAction action) {
+                         u->freezer_state = FREEZER_THAWING;
+         }
+
+-        r = write_string_file(path, one_zero(action == FREEZER_FREEZE), WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(path, one_zero(action == FREEZER_FREEZE), 0);
+         if (r < 0)
+                 return r;
+
+diff --git a/src/core/main.c b/src/core/main.c
+index c0b8126d96..fe676320ba 100644
+--- a/src/core/main.c
++++ b/src/core/main.c
+@@ -1716,7 +1716,7 @@ static void initialize_core_pattern(bool skip_setup) {
+         if (getpid_cached() != 1)
+                 return;
+
+-        r = write_string_file("/proc/sys/kernel/core_pattern", arg_early_core_pattern, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/proc/sys/kernel/core_pattern", arg_early_core_pattern, 0);
+         if (r < 0)
+                 log_warning_errno(r, "Failed to write '%s' to /proc/sys/kernel/core_pattern, ignoring: %m",
+                                   arg_early_core_pattern);
+diff --git a/src/core/smack-setup.c b/src/core/smack-setup.c
+index bcaa237c8d..4032bde19e 100644
+--- a/src/core/smack-setup.c
++++ b/src/core/smack-setup.c
+@@ -319,17 +319,17 @@ int mac_smack_setup(bool *loaded_policy) {
+         }
+
+ #if HAVE_SMACK_RUN_LABEL
+-        r = write_string_file("/proc/self/attr/current", SMACK_RUN_LABEL, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/proc/self/attr/current", SMACK_RUN_LABEL, 0);
+         if (r < 0)
+                 log_warning_errno(r, "Failed to set SMACK label \"" SMACK_RUN_LABEL "\" on self: %m");
+-        r = write_string_file("/sys/fs/smackfs/ambient", SMACK_RUN_LABEL, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/sys/fs/smackfs/ambient", SMACK_RUN_LABEL, 0);
+         if (r < 0)
+                 log_warning_errno(r, "Failed to set SMACK ambient label \"" SMACK_RUN_LABEL "\": %m");
+         r = write_string_file("/sys/fs/smackfs/netlabel",
+-                              "0.0.0.0/0 " SMACK_RUN_LABEL, WRITE_STRING_FILE_DISABLE_BUFFER);
++                              "0.0.0.0/0 " SMACK_RUN_LABEL, 0);
+         if (r < 0)
+                 log_warning_errno(r, "Failed to set SMACK netlabel rule \"0.0.0.0/0 " SMACK_RUN_LABEL "\": %m");
+-        r = write_string_file("/sys/fs/smackfs/netlabel", "127.0.0.1 -CIPSO", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/sys/fs/smackfs/netlabel", "127.0.0.1 -CIPSO", 0);
+         if (r < 0)
+                 log_warning_errno(r, "Failed to set SMACK netlabel rule \"127.0.0.1 -CIPSO\": %m");
+ #endif
+diff --git a/src/hibernate-resume/hibernate-resume.c b/src/hibernate-resume/hibernate-resume.c
+index 9a9df5d22f..75ddec881a 100644
+--- a/src/hibernate-resume/hibernate-resume.c
++++ b/src/hibernate-resume/hibernate-resume.c
+@@ -40,7 +40,7 @@ int main(int argc, char *argv[]) {
+                 return EXIT_FAILURE;
+         }
+
+-        r = write_string_file("/sys/power/resume", FORMAT_DEVNUM(st.st_rdev), WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/sys/power/resume", FORMAT_DEVNUM(st.st_rdev), 0);
+         if (r < 0) {
+                 log_error_errno(r, "Failed to write '" DEVNUM_FORMAT_STR "' to /sys/power/resume: %m", DEVNUM_FORMAT_VAL(st.st_rdev));
+                 return EXIT_FAILURE;
+diff --git a/src/home/homework.c b/src/home/homework.c
+index 28907386a4..f9e45349a7 100644
+--- a/src/home/homework.c
++++ b/src/home/homework.c
+@@ -278,7 +278,7 @@ static void drop_caches_now(void) {
+          * for details. We write "2" into /proc/sys/vm/drop_caches to ensure dentries/inodes are flushed, but
+          * not more. */
+
+-        r = write_string_file("/proc/sys/vm/drop_caches", "2\n", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/proc/sys/vm/drop_caches", "2\n", 0);
+         if (r < 0)
+                 log_warning_errno(r, "Failed to drop caches, ignoring: %m");
+         else
+diff --git a/src/libsystemd/sd-device/sd-device.c b/src/libsystemd/sd-device/sd-device.c
+index 8c65ee3469..153edab081 100644
+--- a/src/libsystemd/sd-device/sd-device.c
++++ b/src/libsystemd/sd-device/sd-device.c
+@@ -2481,7 +2481,7 @@ _public_ int sd_device_set_sysattr_value(sd_device *device, const char *sysattr,
+         if (!value)
+                 return -ENOMEM;
+
+-        r = write_string_file(path, value, WRITE_STRING_FILE_DISABLE_BUFFER | WRITE_STRING_FILE_NOFOLLOW);
++        r = write_string_file(path, value, 0 | WRITE_STRING_FILE_NOFOLLOW);
+         if (r < 0) {
+                 /* On failure, clear cache entry, as we do not know how it fails. */
+                 device_remove_cached_sysattr_value(device, sysattr);
+diff --git a/src/nspawn/nspawn-cgroup.c b/src/nspawn/nspawn-cgroup.c
+index 0deb4ebb30..bae8eead9e 100644
+--- a/src/nspawn/nspawn-cgroup.c
++++ b/src/nspawn/nspawn-cgroup.c
+@@ -122,7 +122,7 @@ int sync_cgroup(pid_t pid, CGroupUnified unified_requested, uid_t uid_shift) {
+         fn = strjoina(tree, cgroup, "/cgroup.procs");
+
+         sprintf(pid_string, PID_FMT, pid);
+-        r = write_string_file(fn, pid_string, WRITE_STRING_FILE_DISABLE_BUFFER|WRITE_STRING_FILE_MKDIR_0755);
++        r = write_string_file(fn, pid_string, WRITE_STRING_FILE_MKDIR_0755);
+         if (r < 0) {
+                 log_error_errno(r, "Failed to move process: %m");
+                 goto finish;
+diff --git a/src/nspawn/nspawn.c b/src/nspawn/nspawn.c
+index 36d336dfc8..8c5c69596b 100644
+--- a/src/nspawn/nspawn.c
++++ b/src/nspawn/nspawn.c
+@@ -2771,7 +2771,7 @@ static int reset_audit_loginuid(void) {
+         if (streq(p, "4294967295"))
+                 return 0;
+
+-        r = write_string_file("/proc/self/loginuid", "4294967295", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/proc/self/loginuid", "4294967295", 0);
+         if (r < 0) {
+                 log_error_errno(r,
+                                 "Failed to reset audit login UID. This probably means that your kernel is too\n"
+@@ -4211,7 +4211,7 @@ static int setup_uid_map(
+                 return log_oom();
+
+         xsprintf(uid_map, "/proc/" PID_FMT "/uid_map", pid);
+-        r = write_string_file(uid_map, s, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(uid_map, s, 0);
+         if (r < 0)
+                 return log_error_errno(r, "Failed to write UID map: %m");
+
+@@ -4221,7 +4221,7 @@ static int setup_uid_map(
+                 return log_oom();
+
+         xsprintf(uid_map, "/proc/" PID_FMT "/gid_map", pid);
+-        r = write_string_file(uid_map, s, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(uid_map, s, 0);
+         if (r < 0)
+                 return log_error_errno(r, "Failed to write GID map: %m");
+
+diff --git a/src/shared/binfmt-util.c b/src/shared/binfmt-util.c
+index a26175474b..1413a9c72c 100644
+--- a/src/shared/binfmt-util.c
++++ b/src/shared/binfmt-util.c
+@@ -46,7 +46,7 @@ int disable_binfmt(void) {
+                 return 0;
+         }
+
+-        r = write_string_file("/proc/sys/fs/binfmt_misc/status", "-1", WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/proc/sys/fs/binfmt_misc/status", "-1", 0);
+         if (r < 0)
+                 return log_warning_errno(r, "Failed to unregister binfmt_misc entries: %m");
+
+diff --git a/src/shared/cgroup-setup.c b/src/shared/cgroup-setup.c
+index 2ea83f05d3..8626bb184c 100644
+--- a/src/shared/cgroup-setup.c
++++ b/src/shared/cgroup-setup.c
+@@ -350,7 +350,7 @@ int cg_attach(const char *controller, const char *path, pid_t pid) {
+
+         xsprintf(c, PID_FMT "\n", pid);
+
+-        r = write_string_file(fs, c, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(fs, c, 0);
+         if (r == -EOPNOTSUPP && cg_is_threaded(controller, path) > 0)
+                 /* When the threaded mode is used, we cannot read/write the file. Let's return recognizable error. */
+                 return -EUCLEAN;
+@@ -887,7 +887,7 @@ int cg_enable_everywhere(
+                                         return log_debug_errno(errno, "Failed to open cgroup.subtree_control file of %s: %m", p);
+                         }
+
+-                        r = write_string_stream(f, s, WRITE_STRING_FILE_DISABLE_BUFFER);
++                        r = write_string_stream(f, s, 0);
+                         if (r < 0) {
+                                 log_debug_errno(r, "Failed to %s controller %s for %s (%s): %m",
+                                                 FLAGS_SET(mask, bit) ? "enable" : "disable", n, p, fs);
+diff --git a/src/shared/coredump-util.c b/src/shared/coredump-util.c
+index 3d2f179049..c1b6c170ac 100644
+--- a/src/shared/coredump-util.c
++++ b/src/shared/coredump-util.c
+@@ -71,7 +71,7 @@ int set_coredump_filter(uint64_t value) {
+         sprintf(t, "0x%"PRIx64, value);
+
+         return write_string_file("/proc/self/coredump_filter", t,
+-                                 WRITE_STRING_FILE_VERIFY_ON_FAILURE|WRITE_STRING_FILE_DISABLE_BUFFER);
++                                 0);
+ }
+
+ /* Turn off core dumps but only if we're running outside of a container. */
+diff --git a/src/shared/smack-util.c b/src/shared/smack-util.c
+index b3b5c905ad..bbfa1973fd 100644
+--- a/src/shared/smack-util.c
++++ b/src/shared/smack-util.c
+@@ -115,7 +115,7 @@ int mac_smack_apply_pid(pid_t pid, const char *label) {
+                 return 0;
+
+         p = procfs_file_alloca(pid, "attr/current");
+-        r = write_string_file(p, label, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file(p, label, 0);
+         if (r < 0)
+                 return r;
+
+diff --git a/src/sleep/sleep.c b/src/sleep/sleep.c
+index 765dd4974f..cd6afb001b 100644
+--- a/src/sleep/sleep.c
++++ b/src/sleep/sleep.c
+@@ -50,7 +50,7 @@ static int write_hibernate_location_info(const HibernateLocation *hibernate_loca
+         assert(hibernate_location->swap);
+
+         xsprintf(resume_str, "%u:%u", major(hibernate_location->devno), minor(hibernate_location->devno));
+-        r = write_string_file("/sys/power/resume", resume_str, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/sys/power/resume", resume_str, 0);
+         if (r < 0)
+                 return log_debug_errno(r, "Failed to write partition device to /sys/power/resume for '%s': '%s': %m",
+                                        hibernate_location->swap->device, resume_str);
+@@ -77,7 +77,7 @@ static int write_hibernate_location_info(const HibernateLocation *hibernate_loca
+         }
+
+         xsprintf(offset_str, "%" PRIu64, hibernate_location->offset);
+-        r = write_string_file("/sys/power/resume_offset", offset_str, WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/sys/power/resume_offset", offset_str, 0);
+         if (r < 0)
+                 return log_debug_errno(r, "Failed to write swap file offset to /sys/power/resume_offset for '%s': '%s': %m",
+                                        hibernate_location->swap->device, offset_str);
+@@ -93,7 +93,7 @@ static int write_mode(char **modes) {
+         STRV_FOREACH(mode, modes) {
+                 int k;
+
+-                k = write_string_file("/sys/power/disk", *mode, WRITE_STRING_FILE_DISABLE_BUFFER);
++                k = write_string_file("/sys/power/disk", *mode, 0);
+                 if (k >= 0)
+                         return 0;
+
+@@ -114,7 +114,7 @@ static int write_state(FILE **f, char **states) {
+         STRV_FOREACH(state, states) {
+                 int k;
+
+-                k = write_string_stream(*f, *state, WRITE_STRING_FILE_DISABLE_BUFFER);
++                k = write_string_stream(*f, *state, 0);
+                 if (k >= 0)
+                         return 0;
+                 log_debug_errno(k, "Failed to write '%s' to /sys/power/state: %m", *state);
+diff --git a/src/udev/udev-rules.c b/src/udev/udev-rules.c
+index 0ce79f815c..28aab475d0 100644
+--- a/src/udev/udev-rules.c
++++ b/src/udev/udev-rules.c
+@@ -2357,7 +2357,6 @@ static int udev_rule_apply_token_to_event(
+                 log_rule_debug(dev, rules, "ATTR '%s' writing '%s'", buf, value);
+                 r = write_string_file(buf, value,
+                                       WRITE_STRING_FILE_VERIFY_ON_FAILURE |
+-                                      WRITE_STRING_FILE_DISABLE_BUFFER |
+                                       WRITE_STRING_FILE_AVOID_NEWLINE |
+                                       WRITE_STRING_FILE_VERIFY_IGNORE_NEWLINE);
+                 if (r < 0)
+diff --git a/src/vconsole/vconsole-setup.c b/src/vconsole/vconsole-setup.c
+index 7d3e9db73f..2d4a0c4c9d 100644
+--- a/src/vconsole/vconsole-setup.c
++++ b/src/vconsole/vconsole-setup.c
+@@ -108,7 +108,7 @@ static int toggle_utf8_vc(const char *name, int fd, bool utf8) {
+ static int toggle_utf8_sysfs(bool utf8) {
+         int r;
+
+-        r = write_string_file("/sys/module/vt/parameters/default_utf8", one_zero(utf8), WRITE_STRING_FILE_DISABLE_BUFFER);
++        r = write_string_file("/sys/module/vt/parameters/default_utf8", one_zero(utf8), 0);
+         if (r < 0)
+                 return log_warning_errno(r, "Failed to %s sysfs UTF-8 flag: %m", enable_disable(utf8));
+
+--
+2.39.2

--- a/sd-measure/patches/0022-Handle-__cpu_mask-usage.patch
+++ b/sd-measure/patches/0022-Handle-__cpu_mask-usage.patch
@@ -1,0 +1,59 @@
+From a50ec65dbe660421052656dda7499c925005f486 Mon Sep 17 00:00:00 2001
+From: Scott Murray <scott.murray@konsulko.com>
+Date: Fri, 13 Sep 2019 19:26:27 -0400
+Subject: [PATCH] Handle __cpu_mask usage
+
+Fixes errors:
+
+src/test/test-cpu-set-util.c:18:54: error: '__cpu_mask' undeclared (first use in this function)
+src/test/test-sizeof.c:73:14: error: '__cpu_mask' undeclared (first use in this function)
+
+__cpu_mask is an internal type of glibc's cpu_set implementation, not
+part of the POSIX definition, which is problematic when building with
+musl, which does not define a matching type.  From inspection of musl's
+sched.h, however, it is clear that the corresponding type would be
+unsigned long, which does match glibc's actual __CPU_MASK_TYPE.  So,
+add a typedef to cpu-set-util.h defining __cpu_mask appropriately.
+
+Upstream-Status: Inappropriate [musl specific]
+
+Signed-off-by: Scott Murray <scott.murray@konsulko.com>
+---
+ src/shared/cpu-set-util.h | 2 ++
+ src/test/test-sizeof.c    | 2 +-
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/shared/cpu-set-util.h b/src/shared/cpu-set-util.h
+index 3c63a58826..4c2d4347fc 100644
+--- a/src/shared/cpu-set-util.h
++++ b/src/shared/cpu-set-util.h
+@@ -6,6 +6,8 @@
+ #include "macro.h"
+ #include "missing_syscall.h"
+
++typedef unsigned long __cpu_mask;
++
+ /* This wraps the libc interface with a variable to keep the allocated size. */
+ typedef struct CPUSet {
+         cpu_set_t *set;
+diff --git a/src/test/test-sizeof.c b/src/test/test-sizeof.c
+index 6cf92bffde..937d26ca55 100644
+--- a/src/test/test-sizeof.c
++++ b/src/test/test-sizeof.c
+@@ -1,6 +1,5 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+
+-#include <sched.h>
+ #include <stdio.h>
+ #include <string.h>
+ #include <sys/types.h>
+@@ -10,6 +9,7 @@
+ #include <float.h>
+
+ #include "time-util.h"
++#include "cpu-set-util.h"
+
+ /* Print information about various types. Useful when diagnosing
+  * gcc diagnostics on an unfamiliar architecture. */
+--
+2.39.2

--- a/sd-measure/patches/0023-Handle-missing-gshadow.patch
+++ b/sd-measure/patches/0023-Handle-missing-gshadow.patch
@@ -1,0 +1,172 @@
+From ebf0f69d8614b8d86a971b97ff0d847d1e5d47c9 Mon Sep 17 00:00:00 2001
+From: Alex Kiernan <alex.kiernan@gmail.com>
+Date: Tue, 10 Mar 2020 11:05:20 +0000
+Subject: [PATCH] Handle missing gshadow
+
+gshadow usage is now present in the userdb code. Mask all uses of it to
+allow compilation on musl
+
+Upstream-Status: Inappropriate [musl specific]
+Signed-off-by: Alex Kiernan <alex.kiernan@gmail.com>
+[Rebased for v247]
+Signed-off-by: Luca Boccassi <luca.boccassi@microsoft.com>
+---
+ src/shared/user-record-nss.c | 20 ++++++++++++++++++++
+ src/shared/user-record-nss.h |  4 ++++
+ src/shared/userdb.c          |  7 ++++++-
+ 3 files changed, 30 insertions(+), 1 deletion(-)
+
+diff --git a/src/shared/user-record-nss.c b/src/shared/user-record-nss.c
+index 88b8fc2f8f..a819d41bac 100644
+--- a/src/shared/user-record-nss.c
++++ b/src/shared/user-record-nss.c
+@@ -331,8 +331,10 @@ int nss_group_to_group_record(
+         if (isempty(grp->gr_name))
+                 return -EINVAL;
+
++#if ENABLE_GSHADOW
+         if (sgrp && !streq_ptr(sgrp->sg_namp, grp->gr_name))
+                 return -EINVAL;
++#endif
+
+         g = group_record_new();
+         if (!g)
+@@ -348,6 +350,7 @@ int nss_group_to_group_record(
+
+         g->gid = grp->gr_gid;
+
++#if ENABLE_GSHADOW
+         if (sgrp) {
+                 if (looks_like_hashed_password(utf8_only(sgrp->sg_passwd))) {
+                         g->hashed_password = strv_new(sgrp->sg_passwd);
+@@ -363,6 +366,7 @@ int nss_group_to_group_record(
+                 if (r < 0)
+                         return r;
+         }
++#endif
+
+         r = json_build(&g->json, JSON_BUILD_OBJECT(
+                                        JSON_BUILD_PAIR("groupName", JSON_BUILD_STRING(g->group_name)),
+@@ -388,6 +392,7 @@ int nss_sgrp_for_group(const struct group *grp, struct sgrp *ret_sgrp, char **re
+         assert(ret_sgrp);
+         assert(ret_buffer);
+
++#if ENABLE_GSHADOW
+         for (;;) {
+                 _cleanup_free_ char *buf = NULL;
+                 struct sgrp sgrp, *result;
+@@ -416,6 +421,9 @@ int nss_sgrp_for_group(const struct group *grp, struct sgrp *ret_sgrp, char **re
+                 buflen *= 2;
+                 buf = mfree(buf);
+         }
++#else
++        return -ESRCH;
++#endif
+ }
+
+ int nss_group_record_by_name(
+@@ -427,7 +435,9 @@ int nss_group_record_by_name(
+         struct group grp, *result;
+         bool incomplete = false;
+         size_t buflen = 4096;
++#if ENABLE_GSHADOW
+         struct sgrp sgrp, *sresult = NULL;
++#endif
+         int r;
+
+         assert(name);
+@@ -457,6 +467,7 @@ int nss_group_record_by_name(
+                 buf = mfree(buf);
+         }
+
++#if ENABLE_GSHADOW
+         if (with_shadow) {
+                 r = nss_sgrp_for_group(result, &sgrp, &sbuf);
+                 if (r < 0) {
+@@ -468,6 +479,9 @@ int nss_group_record_by_name(
+                 incomplete = true;
+
+         r = nss_group_to_group_record(result, sresult, ret);
++#else
++        r = nss_group_to_group_record(result, NULL, ret);
++#endif
+         if (r < 0)
+                 return r;
+
+@@ -484,7 +498,9 @@ int nss_group_record_by_gid(
+         struct group grp, *result;
+         bool incomplete = false;
+         size_t buflen = 4096;
++#if ENABLE_GSHADOW
+         struct sgrp sgrp, *sresult = NULL;
++#endif
+         int r;
+
+         assert(ret);
+@@ -512,6 +528,7 @@ int nss_group_record_by_gid(
+                 buf = mfree(buf);
+         }
+
++#if ENABLE_GSHADOW
+         if (with_shadow) {
+                 r = nss_sgrp_for_group(result, &sgrp, &sbuf);
+                 if (r < 0) {
+@@ -523,6 +540,9 @@ int nss_group_record_by_gid(
+                 incomplete = true;
+
+         r = nss_group_to_group_record(result, sresult, ret);
++#else
++        r = nss_group_to_group_record(result, NULL, ret);
++#endif
+         if (r < 0)
+                 return r;
+
+diff --git a/src/shared/user-record-nss.h b/src/shared/user-record-nss.h
+index 22ab04d6ee..4e52e7a911 100644
+--- a/src/shared/user-record-nss.h
++++ b/src/shared/user-record-nss.h
+@@ -2,7 +2,11 @@
+ #pragma once
+
+ #include <grp.h>
++#if ENABLE_GSHADOW
+ #include <gshadow.h>
++#else
++struct sgrp;
++#endif
+ #include <pwd.h>
+ #include <shadow.h>
+
+diff --git a/src/shared/userdb.c b/src/shared/userdb.c
+index a77eff4407..955e361d3a 100644
+--- a/src/shared/userdb.c
++++ b/src/shared/userdb.c
+@@ -1044,13 +1044,15 @@ int groupdb_iterator_get(UserDBIterator *iterator, GroupRecord **ret) {
+                 if (gr) {
+                         _cleanup_free_ char *buffer = NULL;
+                         bool incomplete = false;
++#if ENABLE_GSHADOW
+                         struct sgrp sgrp;
+-
++#endif
+                         if (streq_ptr(gr->gr_name, "root"))
+                                 iterator->synthesize_root = false;
+                         if (gr->gr_gid == GID_NOBODY)
+                                 iterator->synthesize_nobody = false;
+
++#if ENABLE_GSHADOW
+                         if (!FLAGS_SET(iterator->flags, USERDB_SUPPRESS_SHADOW)) {
+                                 r = nss_sgrp_for_group(gr, &sgrp, &buffer);
+                                 if (r < 0) {
+@@ -1063,6 +1065,9 @@ int groupdb_iterator_get(UserDBIterator *iterator, GroupRecord **ret) {
+                         }
+
+                         r = nss_group_to_group_record(gr, r >= 0 ? &sgrp : NULL, ret);
++#else
++                        r = nss_group_to_group_record(gr, NULL, ret);
++#endif
+                         if (r < 0)
+                                 return r;
+
+--
+2.39.2

--- a/sd-measure/patches/0024-missing_syscall.h-Define-MIPS-ABI-defines-for-musl.patch
+++ b/sd-measure/patches/0024-missing_syscall.h-Define-MIPS-ABI-defines-for-musl.patch
@@ -1,0 +1,48 @@
+From a2f56a2a6cdd5137bb1e680aa9f6c40540107166 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 12 Apr 2021 23:44:53 -0700
+Subject: [PATCH] missing_syscall.h: Define MIPS ABI defines for musl
+
+musl does not define _MIPS_SIM_ABI32, _MIPS_SIM_NABI32, _MIPS_SIM_ABI64
+unlike glibc where these are provided by libc headers, therefore define
+them here in case they are undefined
+
+Upstream-Status: Pending
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/basic/missing_syscall.h  | 6 ++++++
+ src/shared/base-filesystem.c | 1 +
+ 2 files changed, 7 insertions(+)
+
+diff --git a/src/basic/missing_syscall.h b/src/basic/missing_syscall.h
+index 98cd037962..ea6a76c2e2 100644
+--- a/src/basic/missing_syscall.h
++++ b/src/basic/missing_syscall.h
+@@ -20,6 +20,12 @@
+ #include <asm/sgidefs.h>
+ #endif
+
++#ifndef _MIPS_SIM_ABI32
++#define _MIPS_SIM_ABI32	1
++#define _MIPS_SIM_NABI32 2
++#define _MIPS_SIM_ABI64	3
++#endif
++
+ #include "macro.h"
+ #include "missing_keyctl.h"
+ #include "missing_stat.h"
+diff --git a/src/shared/base-filesystem.c b/src/shared/base-filesystem.c
+index 2726dc946a..484f63e0b4 100644
+--- a/src/shared/base-filesystem.c
++++ b/src/shared/base-filesystem.c
+@@ -19,6 +19,7 @@
+ #include "string-util.h"
+ #include "umask-util.h"
+ #include "user-util.h"
++#include "missing_syscall.h"
+
+ typedef struct BaseFilesystem {
+         const char *dir;      /* directory or symlink to create */
+--
+2.39.2

--- a/sd-measure/patches/0026-src-boot-efi-efi-string.c-define-wchar_t-from-__WCHA.patch
+++ b/sd-measure/patches/0026-src-boot-efi-efi-string.c-define-wchar_t-from-__WCHA.patch
@@ -1,0 +1,43 @@
+From 34072f456b4fe880fbb2f18760b64a1a6c1eebb8 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex@linutronix.de>
+Date: Mon, 6 Mar 2023 15:24:49 +0100
+Subject: [PATCH] src/boot/efi/efi-string.c: define wchar_t from __WCHAR_TYPE__
+
+systemd-boot relies on wchar_t being 16 bit, and breaks at build time otherwise.
+
+To set wchar_t to 16 bit it is passing -fshort-wchar to gcc; this has the
+desired effect on glibc (which sets wchar_t from __WCHAR_TYPE__) but not on
+musl (which hardcodes it to 32 bit).
+
+This patch ensures wchar_t is set from the compiler flags on all systems; note
+that systemd-boot is not actually using functions from musl or other libc, just their headers.
+
+Meanwhile upstream has refactored the code to not rely on libc headers at all;
+however this will not be backported to v253 and we need a different fix.
+
+Upstream-Status: Inappropriate [fixed differently in trunk according to https://github.com/systemd/systemd/pull/26689]
+Signed-off-by: Alexander Kanavin <alex@linutronix.de>
+---
+ src/boot/efi/efi-string.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/boot/efi/efi-string.c b/src/boot/efi/efi-string.c
+index 22923d60f6..5d09d4281f 100644
+--- a/src/boot/efi/efi-string.c
++++ b/src/boot/efi/efi-string.c
+@@ -2,7 +2,13 @@
+
+ #include <stdbool.h>
+ #include <stdint.h>
++
++#if SD_BOOT
++typedef __WCHAR_TYPE__ wchar_t;
++#define __DEFINED_wchar_t
++#else
+ #include <wchar.h>
++#endif
+
+ #include "efi-string.h"
+
+--
+2.39.2

--- a/sd-measure/patches/27253.patch
+++ b/sd-measure/patches/27253.patch
@@ -1,0 +1,313 @@
+From 924937cbc0bf692bc6e5b3a0bd3c18347d9521e9 Mon Sep 17 00:00:00 2001
+From: Yu Watanabe <watanabe.yu+github@gmail.com>
+Date: Thu, 13 Apr 2023 16:40:36 +0900
+Subject: [PATCH 1/7] timesync: drop unnecessary initialization
+
+Upstream-Status: Submitted [https://github.com/systemd/systemd/pull/27253]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/timesync/timesyncd-manager.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/src/timesync/timesyncd-manager.c
++++ b/src/timesync/timesyncd-manager.c
+@@ -410,7 +410,7 @@ static int manager_receive_response(sd_e
+                 .msg_name = &server_addr,
+                 .msg_namelen = sizeof(server_addr),
+         };
+-        struct timespec *recv_time = NULL;
++        struct timespec *recv_time;
+         triple_timestamp dts;
+         ssize_t len;
+         double origin, receive, trans, dest, delay, offset, root_distance;
+@@ -445,7 +445,7 @@ static int manager_receive_response(sd_e
+                 return 0;
+         }
+
+-        recv_time = CMSG_FIND_DATA(&msghdr, SOL_SOCKET, SCM_TIMESTAMPNS, struct timespec);
++        recv_time = CMSG_FIND_AND_COPY_DATA(&msghdr, SOL_SOCKET, SCM_TIMESTAMPNS, struct timespec);
+         if (!recv_time)
+                 return log_error_errno(SYNTHETIC_ERRNO(EINVAL), "Packet timestamp missing.");
+
+--- a/src/basic/socket-util.h
++++ b/src/basic/socket-util.h
+@@ -183,17 +183,22 @@ int flush_accept(int fd);
+  * riscv32. */
+ #define CMSG_TYPED_DATA(cmsg, type)                                     \
+         ({                                                              \
+-                struct cmsghdr *_cmsg = cmsg;                           \
+-                assert_cc(__alignof__(type) <= __alignof__(struct cmsghdr)); \
++                struct cmsghdr *_cmsg = (cmsg);                         \
++                assert_cc(alignof(type) <= alignof(struct cmsghdr));    \
+                 _cmsg ? CAST_ALIGN_PTR(type, CMSG_DATA(_cmsg)) : (type*) NULL; \
+         })
+
+ struct cmsghdr* cmsg_find(struct msghdr *mh, int level, int type, socklen_t length);
++void* cmsg_find_and_copy_data(struct msghdr *mh, int level, int type, void *buf, size_t buf_len);
+
+ /* Type-safe, dereferencing version of cmsg_find() */
+ #define CMSG_FIND_DATA(mh, level, type, ctype)                          \
+         CMSG_TYPED_DATA(cmsg_find(mh, level, type, CMSG_LEN(sizeof(ctype))), ctype)
+
++/* Type-safe version of cmsg_find_and_copy_data() */
++#define CMSG_FIND_AND_COPY_DATA(mh, level, type, ctype)             \
++        (ctype*) cmsg_find_and_copy_data(mh, level, type, &(ctype){}, sizeof(ctype))
++
+ /* Resolves to a type that can carry cmsghdr structures. Make sure things are properly aligned, i.e. the type
+  * itself is placed properly in memory and the size is also aligned to what's appropriate for "cmsghdr"
+  * structures. */
+--- a/src/boot/efi/pe.c
++++ b/src/boot/efi/pe.c
+@@ -197,7 +197,7 @@ static uint32_t get_compatibility_entry_
+                 uint32_t entry_point;
+         } _packed_ LinuxPeCompat1;
+
+-        while (size >= sizeof(LinuxPeCompat1) && addr % __alignof__(LinuxPeCompat1) == 0) {
++        while (size >= sizeof(LinuxPeCompat1) && addr % alignof(LinuxPeCompat1) == 0) {
+                 LinuxPeCompat1 *compat = (LinuxPeCompat1 *) ((uint8_t *) dos + addr);
+
+                 if (compat->type == 0 || compat->size == 0 || compat->size > size)
+--- a/src/fundamental/macro-fundamental.h
++++ b/src/fundamental/macro-fundamental.h
+@@ -6,12 +6,13 @@
+ #endif
+
+ #include <limits.h>
++#include <stdalign.h>
+ #include <stdbool.h>
+ #include <stddef.h>
+ #include <stdint.h>
+
+ #define _align_(x) __attribute__((__aligned__(x)))
+-#define _alignas_(x) __attribute__((__aligned__(__alignof__(x))))
++#define _alignas_(x) __attribute__((__aligned__(alignof(x))))
+ #define _alignptr_ __attribute__((__aligned__(sizeof(void *))))
+ #define _cleanup_(x) __attribute__((__cleanup__(x)))
+ #define _const_ __attribute__((__const__))
+@@ -346,9 +347,9 @@ static inline size_t ALIGN_TO(size_t l,
+ #endif
+
+ /* Checks if the specified pointer is aligned as appropriate for the specific type */
+-#define IS_ALIGNED16(p) (((uintptr_t) p) % __alignof__(uint16_t) == 0)
+-#define IS_ALIGNED32(p) (((uintptr_t) p) % __alignof__(uint32_t) == 0)
+-#define IS_ALIGNED64(p) (((uintptr_t) p) % __alignof__(uint64_t) == 0)
++#define IS_ALIGNED16(p) (((uintptr_t) p) % alignof(uint16_t) == 0)
++#define IS_ALIGNED32(p) (((uintptr_t) p) % alignof(uint32_t) == 0)
++#define IS_ALIGNED64(p) (((uintptr_t) p) % alignof(uint64_t) == 0)
+
+ /* Same as ALIGN_TO but callable in constant contexts. */
+ #define CONST_ALIGN_TO(l, ali)                                         \
+@@ -366,7 +367,7 @@ static inline size_t ALIGN_TO(size_t l,
+ #define CAST_ALIGN_PTR(t, p)                                    \
+         ({                                                      \
+                 const void *_p = (p);                           \
+-                assert(((uintptr_t) _p) % __alignof__(t) == 0); \
++                assert(((uintptr_t) _p) % alignof(t) == 0); \
+                 (t *) _p;                                       \
+         })
+
+--- a/src/network/networkd-nexthop.c
++++ b/src/network/networkd-nexthop.c
+@@ -894,7 +894,7 @@ int manager_rtnl_process_nexthop(sd_netl
+                         return 0;
+                 }
+
+-                assert((uintptr_t) group % __alignof__(struct nexthop_grp) == 0);
++                assert((uintptr_t) group % alignof(struct nexthop_grp) == 0);
+
+                 n_group = raw_group_size / sizeof(struct nexthop_grp);
+                 for (size_t i = 0; i < n_group; i++) {
+--- a/src/test/test-sizeof.c
++++ b/src/test/test-sizeof.c
+@@ -17,16 +17,16 @@
+ DISABLE_WARNING_TYPE_LIMITS;
+
+ #define info_no_sign(t)                                                 \
+-        printf("%s → %zu bits, %zu byte alignment\n", STRINGIFY(t),     \
++        printf("%s → %zu bits, %zu byte alignment\n", STRINGIFY(t),    \
+                sizeof(t)*CHAR_BIT,                                      \
+-               __alignof__(t))
++               alignof(t))
+
+ #define info(t)                                                         \
+-        printf("%s → %zu bits%s, %zu byte alignment\n", STRINGIFY(t),   \
++        printf("%s → %zu bits%s, %zu byte alignment\n", STRINGIFY(t),  \
+                sizeof(t)*CHAR_BIT,                                      \
+                strstr(STRINGIFY(t), "signed") ? "" :                    \
+                (t)-1 < (t)0 ? ", signed" : ", unsigned",                \
+-               __alignof__(t))
++               alignof(t))
+
+ enum Enum {
+         enum_value,
+@@ -44,7 +44,7 @@ enum BigEnum2 {
+ int main(void) {
+         int (*function_pointer)(void);
+
+-        info_no_sign(function_pointer);
++        info_no_sign(typeof(function_pointer));
+         info_no_sign(void*);
+         info(char*);
+
+--- a/src/basic/socket-util.c
++++ b/src/basic/socket-util.c
+@@ -1171,6 +1171,18 @@ struct cmsghdr* cmsg_find(struct msghdr
+         return NULL;
+ }
+
++void* cmsg_find_and_copy_data(struct msghdr *mh, int level, int type, void *buf, size_t buf_len) {
++        struct cmsghdr *cmsg;
++
++        assert(mh);
++
++        cmsg = cmsg_find(mh, level, type, buf_len == SIZE_MAX ? (socklen_t) -1 : CMSG_LEN(buf_len));
++        if (!cmsg)
++                return NULL;
++
++        return memcpy_safe(buf, CMSG_DATA(cmsg), buf_len == SIZE_MAX ? cmsg->cmsg_len : buf_len);
++}
++
+ int socket_ioctl_fd(void) {
+         int fd;
+
+--- a/src/journal/journald-server.c
++++ b/src/journal/journald-server.c
+@@ -1385,7 +1385,7 @@ int server_process_datagram(
+         size_t label_len = 0, m;
+         Server *s = ASSERT_PTR(userdata);
+         struct ucred *ucred = NULL;
+-        struct timeval *tv = NULL;
++        struct timeval tv_buf, *tv = NULL;
+         struct cmsghdr *cmsg;
+         char *label = NULL;
+         struct iovec iovec;
+@@ -1461,10 +1461,10 @@ int server_process_datagram(
+                         label = CMSG_TYPED_DATA(cmsg, char);
+                         label_len = cmsg->cmsg_len - CMSG_LEN(0);
+                 } else if (cmsg->cmsg_level == SOL_SOCKET &&
+-                           cmsg->cmsg_type == SO_TIMESTAMP &&
++                           cmsg->cmsg_type == SCM_TIMESTAMP &&
+                            cmsg->cmsg_len == CMSG_LEN(sizeof(struct timeval))) {
+                         assert(!tv);
+-                        tv = CMSG_TYPED_DATA(cmsg, struct timeval);
++                        tv = memcpy(&tv_buf, CMSG_DATA(cmsg), sizeof(struct timeval));
+                 } else if (cmsg->cmsg_level == SOL_SOCKET &&
+                          cmsg->cmsg_type == SCM_RIGHTS) {
+                         assert(!fds);
+--- a/src/libsystemd-network/icmp6-util.c
++++ b/src/libsystemd-network/icmp6-util.c
+@@ -199,9 +199,11 @@ int icmp6_receive(int fd, void *buffer,
+                 }
+
+                 if (cmsg->cmsg_level == SOL_SOCKET &&
+-                    cmsg->cmsg_type == SO_TIMESTAMP &&
+-                    cmsg->cmsg_len == CMSG_LEN(sizeof(struct timeval)))
+-                        triple_timestamp_from_realtime(&t, timeval_load(CMSG_TYPED_DATA(cmsg, struct timeval)));
++                    cmsg->cmsg_type == SCM_TIMESTAMP &&
++                    cmsg->cmsg_len == CMSG_LEN(sizeof(struct timeval))) {
++                        struct timeval *tv = memcpy(&(struct timeval) {}, CMSG_DATA(cmsg), sizeof(struct timeval));
++                        triple_timestamp_from_realtime(&t, timeval_load(tv));
++                }
+         }
+
+         if (!triple_timestamp_is_set(&t))
+--- a/src/libsystemd-network/sd-dhcp6-client.c
++++ b/src/libsystemd-network/sd-dhcp6-client.c
+@@ -1276,7 +1276,6 @@ static int client_receive_message(
+                 .msg_control = &control,
+                 .msg_controllen = sizeof(control),
+         };
+-        struct cmsghdr *cmsg;
+         triple_timestamp t = {};
+         _cleanup_free_ DHCP6Message *message = NULL;
+         struct in6_addr *server_address = NULL;
+@@ -1320,12 +1319,9 @@ static int client_receive_message(
+                 server_address = &sa.in6.sin6_addr;
+         }
+
+-        CMSG_FOREACH(cmsg, &msg) {
+-                if (cmsg->cmsg_level == SOL_SOCKET &&
+-                    cmsg->cmsg_type == SO_TIMESTAMP &&
+-                    cmsg->cmsg_len == CMSG_LEN(sizeof(struct timeval)))
+-                        triple_timestamp_from_realtime(&t, timeval_load(CMSG_TYPED_DATA(cmsg, struct timeval)));
+-        }
++        struct timeval *tv = CMSG_FIND_AND_COPY_DATA(&msg, SOL_SOCKET, SCM_TIMESTAMP, struct timeval);
++        if (tv)
++                triple_timestamp_from_realtime(&t, timeval_load(tv));
+
+         if (client->transaction_id != (message->transaction_id & htobe32(0x00ffffff)))
+                 return 0;
+--- a/src/libsystemd-network/sd-dhcp-server.c
++++ b/src/libsystemd-network/sd-dhcp-server.c
+@@ -407,7 +407,7 @@ static int dhcp_server_send_udp(sd_dhcp_
+                    rather than binding the socket. This will be mostly useful
+                    when we gain support for arbitrary number of server addresses
+                  */
+-                pktinfo = (struct in_pktinfo*) CMSG_DATA(cmsg);
++                pktinfo = CMSG_TYPED_DATA(cmsg, struct in_pktinfo);
+                 assert(pktinfo);
+
+                 pktinfo->ipi_ifindex = server->ifindex;
+@@ -1270,7 +1270,6 @@ static int server_receive_message(sd_eve
+                 .msg_control = &control,
+                 .msg_controllen = sizeof(control),
+         };
+-        struct cmsghdr *cmsg;
+         ssize_t datagram_size, len;
+         int r;
+
+@@ -1306,19 +1305,10 @@ static int server_receive_message(sd_eve
+         if ((size_t) len < sizeof(DHCPMessage))
+                 return 0;
+
+-        CMSG_FOREACH(cmsg, &msg)
+-                if (cmsg->cmsg_level == IPPROTO_IP &&
+-                    cmsg->cmsg_type == IP_PKTINFO &&
+-                    cmsg->cmsg_len == CMSG_LEN(sizeof(struct in_pktinfo))) {
+-                        struct in_pktinfo *info = CMSG_TYPED_DATA(cmsg, struct in_pktinfo);
+-
+-                        /* TODO figure out if this can be done as a filter on
+-                         * the socket, like for IPv6 */
+-                        if (server->ifindex != info->ipi_ifindex)
+-                                return 0;
+-
+-                        break;
+-                }
++        /* TODO figure out if this can be done as a filter on the socket, like for IPv6 */
++        struct in_pktinfo *info = CMSG_FIND_DATA(&msg, IPPROTO_IP, IP_PKTINFO, struct in_pktinfo);
++        if (info && info->ipi_ifindex != server->ifindex)
++                return 0;
+
+         if (sd_dhcp_server_is_in_relay_mode(server)) {
+                 r = dhcp_server_relay_message(server, message, len - sizeof(DHCPMessage), buflen);
+--- a/src/libsystemd/sd-daemon/sd-daemon.c
++++ b/src/libsystemd/sd-daemon/sd-daemon.c
+@@ -567,7 +567,7 @@ _public_ int sd_pid_notify_with_fds(
+                         cmsg->cmsg_type = SCM_CREDENTIALS;
+                         cmsg->cmsg_len = CMSG_LEN(sizeof(struct ucred));
+
+-                        ucred = (struct ucred*) CMSG_DATA(cmsg);
++                        ucred = CMSG_TYPED_DATA(cmsg, struct ucred);
+                         ucred->pid = pid != 0 ? pid : getpid_cached();
+                         ucred->uid = getuid();
+                         ucred->gid = getgid();
+--- a/src/resolve/resolved-manager.c
++++ b/src/resolve/resolved-manager.c
+@@ -984,7 +984,7 @@ static int manager_ipv4_send(
+                 cmsg->cmsg_level = IPPROTO_IP;
+                 cmsg->cmsg_type = IP_PKTINFO;
+
+-                pi = (struct in_pktinfo*) CMSG_DATA(cmsg);
++                pi = CMSG_TYPED_DATA(cmsg, struct in_pktinfo);
+                 pi->ipi_ifindex = ifindex;
+
+                 if (source)
+@@ -1040,7 +1040,7 @@ static int manager_ipv6_send(
+                 cmsg->cmsg_level = IPPROTO_IPV6;
+                 cmsg->cmsg_type = IPV6_PKTINFO;
+
+-                pi = (struct in6_pktinfo*) CMSG_DATA(cmsg);
++                pi = CMSG_TYPED_DATA(cmsg, struct in6_pktinfo);
+                 pi->ipi6_ifindex = ifindex;
+
+                 if (source)

--- a/sd-measure/patches/27254.patch
+++ b/sd-measure/patches/27254.patch
@@ -1,0 +1,345 @@
+From 79dec6f5cc0b72d43dfb0469fa68b5cd023fbaf9 Mon Sep 17 00:00:00 2001
+From: Lennart Poettering <lennart@poettering.net>
+Date: Thu, 13 Apr 2023 10:21:31 +0200
+Subject: [PATCH 1/3] socket-util: tighten aignment check for CMSG_TYPED_DATA()
+
+Apparently CMSG_DATA() alignment is very much undefined. Which is quite
+an ABI fuck-up, but we need to deal with this. CMSG_TYPED_DATA() already
+checks alignment of the specified pointer. Let's also check matching
+alignment of the underlying structures, which we already can do at
+compile-time.
+
+See: #27241
+
+(This does not fix #27241, but should catch such errors already at
+compile-time instead of runtime)
+
+Upstream-Status: Backport [https://github.com/systemd/systemd/pull/27254]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ src/basic/socket-util.h | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+--- a/src/basic/socket-util.h
++++ b/src/basic/socket-util.h
+@@ -175,9 +175,16 @@ int flush_accept(int fd);
+ #define CMSG_FOREACH(cmsg, mh)                                          \
+         for ((cmsg) = CMSG_FIRSTHDR(mh); (cmsg); (cmsg) = CMSG_NXTHDR((mh), (cmsg)))
+
++/* Returns the cmsghdr's data pointer, but safely cast to the specified type. Does two alignment checks: one
++ * at compile time, that the requested type has a smaller or same alignment as 'struct cmsghdr', and one
++ * during runtime, that the actual pointer matches the alignment too. This is supposed to catch cases such as
++ * 'struct timeval' is embedded into 'struct cmsghdr' on architectures where the alignment of the former is 8
++ * bytes (because of a 64bit time_t), but of the latter is 4 bytes (because size_t is 32bit), such as
++ * riscv32. */
+ #define CMSG_TYPED_DATA(cmsg, type)                                     \
+         ({                                                              \
+                 struct cmsghdr *_cmsg = cmsg;                           \
++                assert_cc(__alignof__(type) <= __alignof__(struct cmsghdr)); \
+                 _cmsg ? CAST_ALIGN_PTR(type, CMSG_DATA(_cmsg)) : (type*) NULL; \
+         })
+
+--- a/src/basic/socket-util.c
++++ b/src/basic/socket-util.c
+@@ -1047,7 +1047,7 @@ ssize_t receive_one_fd_iov(
+         }
+
+         if (found)
+-                *ret_fd = *(int*) CMSG_DATA(found);
++                *ret_fd = *CMSG_TYPED_DATA(found, int);
+         else
+                 *ret_fd = -EBADF;
+
+--- a/src/core/manager.c
++++ b/src/core/manager.c
+@@ -2503,7 +2503,7 @@ static int manager_dispatch_notify_fd(sd
+                 if (cmsg->cmsg_level == SOL_SOCKET && cmsg->cmsg_type == SCM_RIGHTS) {
+
+                         assert(!fd_array);
+-                        fd_array = (int*) CMSG_DATA(cmsg);
++                        fd_array = CMSG_TYPED_DATA(cmsg, int);
+                         n_fds = (cmsg->cmsg_len - CMSG_LEN(0)) / sizeof(int);
+
+                 } else if (cmsg->cmsg_level == SOL_SOCKET &&
+@@ -2511,7 +2511,7 @@ static int manager_dispatch_notify_fd(sd
+                            cmsg->cmsg_len == CMSG_LEN(sizeof(struct ucred))) {
+
+                         assert(!ucred);
+-                        ucred = (struct ucred*) CMSG_DATA(cmsg);
++                        ucred = CMSG_TYPED_DATA(cmsg, struct ucred);
+                 }
+         }
+
+--- a/src/coredump/coredump.c
++++ b/src/coredump/coredump.c
+@@ -1163,7 +1163,7 @@ static int process_socket(int fd) {
+                         }
+
+                         assert(input_fd < 0);
+-                        input_fd = *(int*) CMSG_DATA(found);
++                        input_fd = *CMSG_TYPED_DATA(found, int);
+                         break;
+                 } else
+                         cmsg_close_all(&mh);
+--- a/src/home/homed-manager.c
++++ b/src/home/homed-manager.c
+@@ -1086,7 +1086,7 @@ static ssize_t read_datagram(
+                     cmsg->cmsg_type == SCM_CREDENTIALS &&
+                     cmsg->cmsg_len == CMSG_LEN(sizeof(struct ucred))) {
+                         assert(!sender);
+-                        sender = (struct ucred*) CMSG_DATA(cmsg);
++                        sender = CMSG_TYPED_DATA(cmsg, struct ucred);
+                 }
+
+                 if (cmsg->cmsg_level == SOL_SOCKET &&
+@@ -1098,7 +1098,7 @@ static ssize_t read_datagram(
+                         }
+
+                         assert(passed_fd < 0);
+-                        passed_fd = *(int*) CMSG_DATA(cmsg);
++                        passed_fd = *CMSG_TYPED_DATA(cmsg, int);
+                 }
+         }
+
+--- a/src/journal/journald-server.c
++++ b/src/journal/journald-server.c
+@@ -1454,21 +1454,21 @@ int server_process_datagram(
+                     cmsg->cmsg_type == SCM_CREDENTIALS &&
+                     cmsg->cmsg_len == CMSG_LEN(sizeof(struct ucred))) {
+                         assert(!ucred);
+-                        ucred = (struct ucred*) CMSG_DATA(cmsg);
++                        ucred = CMSG_TYPED_DATA(cmsg, struct ucred);
+                 } else if (cmsg->cmsg_level == SOL_SOCKET &&
+                          cmsg->cmsg_type == SCM_SECURITY) {
+                         assert(!label);
+-                        label = (char*) CMSG_DATA(cmsg);
++                        label = CMSG_TYPED_DATA(cmsg, char);
+                         label_len = cmsg->cmsg_len - CMSG_LEN(0);
+                 } else if (cmsg->cmsg_level == SOL_SOCKET &&
+                            cmsg->cmsg_type == SO_TIMESTAMP &&
+                            cmsg->cmsg_len == CMSG_LEN(sizeof(struct timeval))) {
+                         assert(!tv);
+-                        tv = (struct timeval*) CMSG_DATA(cmsg);
++                        tv = CMSG_TYPED_DATA(cmsg, struct timeval);
+                 } else if (cmsg->cmsg_level == SOL_SOCKET &&
+                          cmsg->cmsg_type == SCM_RIGHTS) {
+                         assert(!fds);
+-                        fds = (int*) CMSG_DATA(cmsg);
++                        fds = CMSG_TYPED_DATA(cmsg, int);
+                         n_fds = (cmsg->cmsg_len - CMSG_LEN(0)) / sizeof(int);
+                 }
+
+--- a/src/libsystemd-network/icmp6-util.c
++++ b/src/libsystemd-network/icmp6-util.c
+@@ -192,7 +192,7 @@ int icmp6_receive(int fd, void *buffer,
+                 if (cmsg->cmsg_level == SOL_IPV6 &&
+                     cmsg->cmsg_type == IPV6_HOPLIMIT &&
+                     cmsg->cmsg_len == CMSG_LEN(sizeof(int))) {
+-                        int hops = *(int*) CMSG_DATA(cmsg);
++                        int hops = *CMSG_TYPED_DATA(cmsg, int);
+
+                         if (hops != 255)
+                                 return -EMULTIHOP;
+@@ -201,7 +201,7 @@ int icmp6_receive(int fd, void *buffer,
+                 if (cmsg->cmsg_level == SOL_SOCKET &&
+                     cmsg->cmsg_type == SO_TIMESTAMP &&
+                     cmsg->cmsg_len == CMSG_LEN(sizeof(struct timeval)))
+-                        triple_timestamp_from_realtime(&t, timeval_load((struct timeval*) CMSG_DATA(cmsg)));
++                        triple_timestamp_from_realtime(&t, timeval_load(CMSG_TYPED_DATA(cmsg, struct timeval)));
+         }
+
+         if (!triple_timestamp_is_set(&t))
+--- a/src/libsystemd-network/sd-dhcp-client.c
++++ b/src/libsystemd-network/sd-dhcp-client.c
+@@ -1981,7 +1981,7 @@ static int client_receive_message_raw(
+
+         cmsg = cmsg_find(&msg, SOL_PACKET, PACKET_AUXDATA, CMSG_LEN(sizeof(struct tpacket_auxdata)));
+         if (cmsg) {
+-                struct tpacket_auxdata *aux = (struct tpacket_auxdata*) CMSG_DATA(cmsg);
++                struct tpacket_auxdata *aux = CMSG_TYPED_DATA(cmsg, struct tpacket_auxdata);
+                 checksum = !(aux->tp_status & TP_STATUS_CSUMNOTREADY);
+         }
+
+--- a/src/libsystemd-network/sd-dhcp-server.c
++++ b/src/libsystemd-network/sd-dhcp-server.c
+@@ -1310,7 +1310,7 @@ static int server_receive_message(sd_eve
+                 if (cmsg->cmsg_level == IPPROTO_IP &&
+                     cmsg->cmsg_type == IP_PKTINFO &&
+                     cmsg->cmsg_len == CMSG_LEN(sizeof(struct in_pktinfo))) {
+-                        struct in_pktinfo *info = (struct in_pktinfo*)CMSG_DATA(cmsg);
++                        struct in_pktinfo *info = CMSG_TYPED_DATA(cmsg, struct in_pktinfo);
+
+                         /* TODO figure out if this can be done as a filter on
+                          * the socket, like for IPv6 */
+--- a/src/libsystemd/sd-bus/bus-socket.c
++++ b/src/libsystemd/sd-bus/bus-socket.c
+@@ -604,7 +604,7 @@ static int bus_socket_read_auth(sd_bus *
+                                  * protocol? Somebody is playing games with
+                                  * us. Close them all, and fail */
+                                 j = (cmsg->cmsg_len - CMSG_LEN(0)) / sizeof(int);
+-                                close_many((int*) CMSG_DATA(cmsg), j);
++                                close_many(CMSG_TYPED_DATA(cmsg, int), j);
+                                 return -EIO;
+                         } else
+                                 log_debug("Got unexpected auxiliary data with level=%d and type=%d",
+@@ -1270,18 +1270,18 @@ int bus_socket_read_message(sd_bus *bus)
+                                          * isn't actually enabled? Close them,
+                                          * and fail */
+
+-                                        close_many((int*) CMSG_DATA(cmsg), n);
++                                        close_many(CMSG_TYPED_DATA(cmsg, int), n);
+                                         return -EIO;
+                                 }
+
+                                 f = reallocarray(bus->fds, bus->n_fds + n, sizeof(int));
+                                 if (!f) {
+-                                        close_many((int*) CMSG_DATA(cmsg), n);
++                                        close_many(CMSG_TYPED_DATA(cmsg, int), n);
+                                         return -ENOMEM;
+                                 }
+
+                                 for (i = 0; i < n; i++)
+-                                        f[bus->n_fds++] = fd_move_above_stdio(((int*) CMSG_DATA(cmsg))[i]);
++                                        f[bus->n_fds++] = fd_move_above_stdio(CMSG_TYPED_DATA(cmsg, int)[i]);
+                                 bus->fds = f;
+                         } else
+                                 log_debug("Got unexpected auxiliary data with level=%d and type=%d",
+--- a/src/resolve/resolved-dns-stream.c
++++ b/src/resolve/resolved-dns-stream.c
+@@ -147,7 +147,7 @@ static int dns_stream_identify(DnsStream
+                         switch (cmsg->cmsg_type) {
+
+                         case IPV6_PKTINFO: {
+-                                struct in6_pktinfo *i = (struct in6_pktinfo*) CMSG_DATA(cmsg);
++                                struct in6_pktinfo *i = CMSG_TYPED_DATA(cmsg, struct in6_pktinfo);
+
+                                 if (s->ifindex <= 0)
+                                         s->ifindex = i->ipi6_ifindex;
+@@ -155,7 +155,7 @@ static int dns_stream_identify(DnsStream
+                         }
+
+                         case IPV6_HOPLIMIT:
+-                                s->ttl = *(int *) CMSG_DATA(cmsg);
++                                s->ttl = *CMSG_TYPED_DATA(cmsg, int);
+                                 break;
+                         }
+
+@@ -165,7 +165,7 @@ static int dns_stream_identify(DnsStream
+                         switch (cmsg->cmsg_type) {
+
+                         case IP_PKTINFO: {
+-                                struct in_pktinfo *i = (struct in_pktinfo*) CMSG_DATA(cmsg);
++                                struct in_pktinfo *i = CMSG_TYPED_DATA(cmsg, struct in_pktinfo);
+
+                                 if (s->ifindex <= 0)
+                                         s->ifindex = i->ipi_ifindex;
+@@ -173,7 +173,7 @@ static int dns_stream_identify(DnsStream
+                         }
+
+                         case IP_TTL:
+-                                s->ttl = *(int *) CMSG_DATA(cmsg);
++                                s->ttl = *CMSG_TYPED_DATA(cmsg, int);
+                                 break;
+                         }
+                 }
+--- a/src/resolve/resolved-manager.c
++++ b/src/resolve/resolved-manager.c
+@@ -801,7 +801,7 @@ int manager_recv(Manager *m, int fd, Dns
+                         switch (cmsg->cmsg_type) {
+
+                         case IPV6_PKTINFO: {
+-                                struct in6_pktinfo *i = (struct in6_pktinfo*) CMSG_DATA(cmsg);
++                                struct in6_pktinfo *i = CMSG_TYPED_DATA(cmsg, struct in6_pktinfo);
+
+                                 if (p->ifindex <= 0)
+                                         p->ifindex = i->ipi6_ifindex;
+@@ -811,11 +811,11 @@ int manager_recv(Manager *m, int fd, Dns
+                         }
+
+                         case IPV6_HOPLIMIT:
+-                                p->ttl = *(int *) CMSG_DATA(cmsg);
++                                p->ttl = *CMSG_TYPED_DATA(cmsg, int);
+                                 break;
+
+                         case IPV6_RECVFRAGSIZE:
+-                                p->fragsize = *(int *) CMSG_DATA(cmsg);
++                                p->fragsize = *CMSG_TYPED_DATA(cmsg, int);
+                                 break;
+                         }
+                 } else if (cmsg->cmsg_level == IPPROTO_IP) {
+@@ -824,7 +824,7 @@ int manager_recv(Manager *m, int fd, Dns
+                         switch (cmsg->cmsg_type) {
+
+                         case IP_PKTINFO: {
+-                                struct in_pktinfo *i = (struct in_pktinfo*) CMSG_DATA(cmsg);
++                                struct in_pktinfo *i = CMSG_TYPED_DATA(cmsg, struct in_pktinfo);
+
+                                 if (p->ifindex <= 0)
+                                         p->ifindex = i->ipi_ifindex;
+@@ -834,11 +834,11 @@ int manager_recv(Manager *m, int fd, Dns
+                         }
+
+                         case IP_TTL:
+-                                p->ttl = *(int *) CMSG_DATA(cmsg);
++                                p->ttl = *CMSG_TYPED_DATA(cmsg, int);
+                                 break;
+
+                         case IP_RECVFRAGSIZE:
+-                                p->fragsize = *(int *) CMSG_DATA(cmsg);
++                                p->fragsize = *CMSG_TYPED_DATA(cmsg, int);
+                                 break;
+                         }
+                 }
+--- a/src/libsystemd/sd-device/device-monitor.c
++++ b/src/libsystemd/sd-device/device-monitor.c
+@@ -503,7 +503,6 @@ int device_monitor_receive_device(sd_dev
+                 .msg_name = &snl,
+                 .msg_namelen = sizeof(snl),
+         };
+-        struct cmsghdr *cmsg;
+         struct ucred *cred;
+         size_t offset;
+         ssize_t n;
+@@ -559,12 +558,11 @@ int device_monitor_receive_device(sd_dev
+                                                  snl.nl.nl_pid);
+         }
+
+-        cmsg = CMSG_FIRSTHDR(&smsg);
+-        if (!cmsg || cmsg->cmsg_type != SCM_CREDENTIALS)
++        cred = CMSG_FIND_DATA(&smsg, SOL_SOCKET, SCM_CREDENTIALS, struct ucred);
++        if (!cred)
+                 return log_monitor_errno(m, SYNTHETIC_ERRNO(EAGAIN),
+                                          "No sender credentials received, ignoring message.");
+
+-        cred = (struct ucred*) CMSG_DATA(cmsg);
+         if (!check_sender_uid(m, cred->uid))
+                 return log_monitor_errno(m, SYNTHETIC_ERRNO(EAGAIN),
+                                          "Sender uid="UID_FMT", message ignored.", cred->uid);
+--- a/src/udev/udev-ctrl.c
++++ b/src/udev/udev-ctrl.c
+@@ -161,7 +161,6 @@ static int udev_ctrl_connection_event_ha
+                 .msg_control = &control,
+                 .msg_controllen = sizeof(control),
+         };
+-        struct cmsghdr *cmsg;
+         struct ucred *cred;
+         ssize_t size;
+
+@@ -185,15 +184,12 @@ static int udev_ctrl_connection_event_ha
+
+         cmsg_close_all(&smsg);
+
+-        cmsg = CMSG_FIRSTHDR(&smsg);
+-
+-        if (!cmsg || cmsg->cmsg_type != SCM_CREDENTIALS) {
++        cred = CMSG_FIND_DATA(&smsg, SOL_SOCKET, SCM_CREDENTIALS, struct ucred);
++        if (!cred) {
+                 log_error("No sender credentials received, ignoring message");
+                 return 0;
+         }
+
+-        cred = (struct ucred *) CMSG_DATA(cmsg);
+-
+         if (cred->uid != 0) {
+                 log_error("Invalid sender uid "UID_FMT", ignoring message", cred->uid);
+                 return 0;

--- a/sd-measure/patches/musl.patch
+++ b/sd-measure/patches/musl.patch
@@ -1,0 +1,12 @@
+diff --git src/basic/stdio-util.h src/basic/stdio-util.h
+index 4e93ac90c9..8631cf834c 100644
+--- src/basic/stdio-util.h
++++ src/basic/stdio-util.h
+@@ -1,7 +1,6 @@
+ /* SPDX-License-Identifier: LGPL-2.1-or-later */
+ #pragma once
+
+-#include <printf.h>
+ #include <stdarg.h>
+ #include <stdio.h>
+ #include <sys/types.h>

--- a/sd-measure/pkg.yaml
+++ b/sd-measure/pkg.yaml
@@ -1,0 +1,102 @@
+name: sd-measure
+dependencies:
+  - stage: base
+  - stage: coreutils
+  - stage: gnuefi
+  - stage: gperf
+  - stage: libcap
+  - stage: meson
+    runtime: true
+  - stage: openssl
+  - stage: patch
+    runtime: true
+  - stage: pkg-config
+    runtime: true
+  - stage: python3
+  - stage: tpm2-tss
+  - stage: util-linux
+steps:
+  - sources:
+      - url: https://github.com/systemd/systemd/archive/refs/tags/v{{ .systemd_version }}.tar.gz
+        destination: systemd.tar.gz
+        sha256: "{{ .systemd_sha256 }}"
+        sha512: "{{ .systemd_sha512 }}"
+    env:
+      LD_LIBRARY_PATH: "/toolchain/lib"
+      # https://github.com/openembedded/openembedded-core/blob/4d24749e7e94881bb952f5c927f0012eb70d4390/meta/recipes-core/systemd/systemd_253.3.bb#L117
+      CFLAGS: "-D_LARGEFILE64_SOURCE -D__UAPI_DEF_ETHHDR=0"
+      CPPFLAGS: "-D_LARGEFILE64_SOURCE -D__UAPI_DEF_ETHHDR=0"
+      CXXFLAGS: "-D_LARGEFILE64_SOURCE -D__UAPI_DEF_ETHHDR=0"
+    prepare:
+      - |
+        tar -xzf systemd.tar.gz --strip-components=1
+
+        ln -s /toolchain/bin/echo /toolchain/bin/getent
+        mkdir -p /usr/bin
+        ln -sf /toolchain/bin/env /usr/bin/env
+        ln -sf /toolchain/bin/python3 /toolchain/bin/python
+
+        pip3 install jinja2 ninja
+
+        # https://github.com/openembedded/openembedded-core/blob/4d24749e7e94881bb952f5c927f0012eb70d4390/meta/recipes-core/systemd/systemd_253.3.bb#L101
+        patch -p1 < /pkg/patches/27254.patch
+        patch -p1 < /pkg/patches/27253.patch
+
+        # https://github.com/openembedded/openembedded-core/blob/4d24749e7e94881bb952f5c927f0012eb70d4390/meta/recipes-core/systemd/systemd_253.3.bb#L34
+        patch -p1 < /pkg/patches/0009-missing_type.h-add-comparison_fn_t.patch
+        patch -p1 < /pkg/patches/0010-add-fallback-parse_printf_format-implementation.patch
+        patch -p1 < /pkg/patches/0011-src-basic-missing.h-check-for-missing-strndupa.patch
+        patch -p1 < /pkg/patches/0012-don-t-fail-if-GLOB_BRACE-and-GLOB_ALTDIRFUNC-is-not-.patch
+        patch -p1 < /pkg/patches/0013-add-missing-FTW_-macros-for-musl.patch
+        patch -p1 < /pkg/patches/0014-Use-uintmax_t-for-handling-rlim_t.patch
+        patch -p1 < /pkg/patches/0015-test-sizeof.c-Disable-tests-for-missing-typedefs-in-.patch
+        patch -p1 < /pkg/patches/0016-don-t-pass-AT_SYMLINK_NOFOLLOW-flag-to-faccessat.patch
+        patch -p1 < /pkg/patches/0017-Define-glibc-compatible-basename-for-non-glibc-syste.patch
+        patch -p1 < /pkg/patches/0018-Do-not-disable-buffering-when-writing-to-oom_score_a.patch
+        patch -p1 < /pkg/patches/0019-distinguish-XSI-compliant-strerror_r-from-GNU-specif.patch
+        patch -p1 < /pkg/patches/0020-avoid-redefinition-of-prctl_mm_map-structure.patch
+        patch -p1 < /pkg/patches/0021-do-not-disable-buffer-in-writing-files.patch
+        patch -p1 < /pkg/patches/0022-Handle-__cpu_mask-usage.patch
+        patch -p1 < /pkg/patches/0023-Handle-missing-gshadow.patch
+        patch -p1 < /pkg/patches/0024-missing_syscall.h-Define-MIPS-ABI-defines-for-musl.patch
+        patch -p1 < /pkg/patches/0005-pass-correct-parameters-to-getdents64.patch
+        patch -p1 < /pkg/patches/0007-Add-sys-stat.h-for-S_IFDIR.patch
+        patch -p1 < /pkg/patches/0001-Adjust-for-musl-headers.patch
+        patch -p1 < /pkg/patches/0006-test-bus-error-strerror-is-assumed-to-be-GNU-specifi.patch
+        patch -p1 < /pkg/patches/0003-errno-util-Make-STRERROR-portable-for-musl.patch
+
+        # # https://github.com/openembedded/openembedded-core/blob/4d24749e7e94881bb952f5c927f0012eb70d4390/meta/recipes-core/systemd/systemd_253.3.bb#L101
+        meson setup build \
+          --buildtype=release \
+          -Dmode=release \
+          -Dsbat-distro=talos \
+          -Dsbat-distro-summary="Talos Linux" \
+          -Dsbat-distro-url=https://github.com/siderolabs/tools/issues \
+          -Dman=false \
+          -Defi=true \
+          -Dgnu-efi=true \
+          -Defi-libdir=/toolchain/lib \
+          -Defi-includedir=/toolchain/include/efi \
+          -Dtpm2=true \
+          -Dgshadow=false \
+          -Didn=false \
+          -Dlocaled=false \
+          -Dnss-mymachines=false \
+          -Dnss-resolve=false \
+          -Dsysusers=false \
+          -Duserdb=false \
+          -Dutmp=false
+    build:
+      - |
+        # might as well copy ukify here
+        ninja -j $(nproc) -C build systemd-measure ukify
+    install:
+      - |
+        mkdir -p /rootfs/toolchain/{bin,lib}
+
+        cp build/systemd-measure /rootfs/toolchain/bin
+        cp build/ukify /rootfs/toolchain/bin
+        cp build/src/shared/libsystemd-shared-{{ .systemd_version }}.so /rootfs/toolchain/lib
+finalize:
+  - from: /rootfs
+    to: /

--- a/sd-stub/patches/musl.patch
+++ b/sd-stub/patches/musl.patch
@@ -1,0 +1,40 @@
+From a4ff7772acf1d983921833aa20ccd7c4d5e59a1c Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex@linutronix.de>
+Date: Mon, 6 Mar 2023 15:24:49 +0100
+Subject: [PATCH] src/boot/efi/efi-string.c: define wchar_t from __WCHAR_TYPE__
+
+systemd-boot relies on wchar_t being 16 bit, and breaks at build time otherwise.
+
+To set wchar_t to 16 bit it is passing -fshort-wchar to gcc; this has the
+desired effect on glibc (which sets wchar_t from __WCHAR_TYPE__) but not on
+musl (which hardcodes it to 32 bit).
+
+This patch ensures wchar_t is set from the compiler flags on all systems; note
+that systemd-boot is not actually using functions from musl or other libc, just their headers.
+
+Meanwhile upstream has refactored the code to not rely on libc headers at all;
+however this will not be backported to v253 and we need a different fix.
+
+Upstream-Status: Inappropriate [fixed differently in trunk according to https://github.com/systemd/systemd/pull/26689]
+Signed-off-by: Alexander Kanavin <alex@linutronix.de>
+---
+ src/boot/efi/efi-string.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/src/boot/efi/efi-string.c b/src/boot/efi/efi-string.c
+index 22923d60f6..22a8d1ef71 100644
+--- a/src/boot/efi/efi-string.c
++++ b/src/boot/efi/efi-string.c
+@@ -2,7 +2,13 @@
+
+ #include <stdbool.h>
+ #include <stdint.h>
++
++#if SD_BOOT
++typedef __WCHAR_TYPE__ wchar_t;
++#define __DEFINED_wchar_t
++#else
+ #include <wchar.h>
++#endif
+
+ #include "efi-string.h"

--- a/sd-stub/pkg.yaml
+++ b/sd-stub/pkg.yaml
@@ -1,0 +1,62 @@
+name: sd-stub
+dependencies:
+  - stage: base
+  - stage: coreutils
+  - stage: gnuefi
+  - stage: gperf
+  - stage: libcap
+  - stage: meson
+    runtime: true
+  - stage: openssl
+  - stage: patch
+    runtime: true
+  - stage: pkg-config
+    runtime: true
+  - stage: python3
+  - stage: tpm2-tss
+  - stage: util-linux
+steps:
+  - sources:
+      - url: https://github.com/systemd/systemd/archive/refs/tags/v{{ .systemd_version }}.tar.gz
+        destination: systemd.tar.gz
+        sha256: "{{ .systemd_sha256 }}"
+        sha512: "{{ .systemd_sha512 }}"
+    env:
+      LD_LIBRARY_PATH: "/toolchain/lib"
+    prepare:
+      - |
+        tar -xzf systemd.tar.gz --strip-components=1
+
+        ln -s /toolchain/bin/echo /toolchain/bin/getent
+        mkdir -p /usr/bin
+        ln -sf /toolchain/bin/env /usr/bin/env
+        ln -sf /toolchain/bin/python3 /toolchain/bin/python
+
+        pip3 install jinja2 ninja
+
+        patch -p1 < /pkg/patches/musl.patch
+
+        meson setup build \
+          --buildtype=release \
+          -Dmode=release \
+          -Dsbat-distro=talos \
+          -Dsbat-distro-summary="Talos Linux" \
+          -Dsbat-distro-url=https://github.com/siderolabs/tools/issues \
+          -Dman=false \
+          -Defi=true \
+          -Dgnu-efi=true \
+          -Defi-libdir=/toolchain/lib \
+          -Defi-includedir=/toolchain/include/efi \
+          -Dtpm2=true \
+          -Dtests=false
+    build:
+      - |
+        ninja -j $(nproc) -C build systemd-stub
+    install:
+      - |
+        mkdir -p /rootfs/toolchain/lib/systemd/boot/efi
+
+        cp build/src/boot/efi/*.efi.stub /rootfs/toolchain/lib/systemd/boot/efi
+finalize:
+  - from: /rootfs
+    to: /

--- a/tools/pkg.yaml
+++ b/tools/pkg.yaml
@@ -39,6 +39,7 @@ dependencies:
   - stage: kmod
   - stage: libbpf
   - stage: libffi
+  - stage: libjson-c
   - stage: libnl
   - stage: libtool
   - stage: libcap
@@ -68,9 +69,13 @@ dependencies:
   - stage: sed
   - stage: squashfs-tools
   - stage: swig
+  - stage: sd-boot
+  - stage: sd-measure
+  - stage: sd-stub
   - stage: tar
   - stage: tcl
   - stage: texinfo
+  - stage: tpm2-tss
   - stage: util-linux
   - stage: xz
   - stage: zlib

--- a/tpm2-tss/pkg.yaml
+++ b/tpm2-tss/pkg.yaml
@@ -1,0 +1,41 @@
+name: tpm2-tss
+dependencies:
+  - stage: base
+  - stage: pkg-config
+    runtime: true
+  - stage: curl
+  - stage: openssl
+  - stage: libjson-c
+  - stage: util-linux
+steps:
+  - sources:
+      - url: https://github.com/tpm2-software/tpm2-tss/releases/download/{{ .tpm2_tss_version }}/tpm2-tss-{{ .tpm2_tss_version }}.tar.gz
+        destination: tpm2-tss.tar.gz
+        sha256: "{{ .tpm2_tss_sha256 }}"
+        sha512: "{{ .tpm2_tss_sha512 }}"
+    prepare:
+      - |
+        tar -xf tpm2-tss.tar.gz --strip-components=1
+
+        ./configure \
+          --prefix=${TOOLCHAIN} \
+          --disable-weakcrypto \
+          --disable-doxygen-doc \
+          --disable-doxygen-man \
+          --disable-doxygen-rtf \
+          --disable-doxygen-xml \
+          --disable-doxygen-chm \
+          --disable-doxygen-chi \
+          --disable-doxygen-html \
+          --disable-doxygen-ps \
+          --disable-doxygen-pdf
+    build:
+      - |
+        make -j $(nproc)
+    install:
+      - |
+        make DESTDIR=/rootfs install
+        rm -rf /rootfs/toolchain/{etc,share}
+finalize:
+  - from: /rootfs
+    to: /


### PR DESCRIPTION
Add sd-tools required for SecureBoot.

Build sd-tools in `tools` since `sd-boot` and `sd-stub` are efi PE executables.