### PR TITLE
chore: bump dependencies

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -48,9 +48,9 @@ vars:
   ccan_sha512: 35a1c1de05a755df50a75440865146dd363c47015be6fa84250888f01e6bab1661c3af5db0340e1fd7f9f84db388fb2d5fcd0d86d0e1bde34ed13b23d673d740
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=https://gitlab.kitware.com/cmake/cmake.git
-  cmake_version: 3.26.3
-  cmake_sha256: bbd8d39217509d163cb544a40d6428ac666ddc83e22905d3e52c925781f0f659
-  cmake_sha512: b09447318512b91c772e36c764049789224032c6c650289a94f6311f999ca104b617bf2dced57b723da23472f015549affabd9c8c076857490c47a1aee7eb7a0
+  cmake_version: 3.26.4
+  cmake_sha256: 313b6880c291bd4fe31c0aa51d6e62659282a521e695f30d5cc0d25abbd5c208
+  cmake_sha512: fe817c8d5e247db3f0a9a58ee37c466a47220100d9e90711cd5d06c223cef87e41d1a756e75d1537e5f8cd010dcb8971cbeab4684b1ac12bcecf84bf7b720167
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.savannah.gnu.org/coreutils.git
   coreutils_version: 9.3
@@ -63,9 +63,9 @@ vars:
   cpio_sha512: 1e1ca6b3e3e64f206f9d828a152d6b4f8f6974de7a953ff96e02698b1c3c2c777c2111450e6a71c0693e29ca8bc01c3dda9f5e829b8e3221f647414df49dff6a
 
   # renovate: datasource=github-releases extractVersion=^curl-(?<version>.*)$ depName=curl/curl
-  curl_version: 8_0_1
-  curl_sha256: 0a381cd82f4d00a9a334438b8ca239afea5bfefcfa9a1025f2bf118e79e0b5f0
-  curl_sha512: 3bb777982659ed697ae90f113ff7b65d6ce8ba9fe6a8984cfd6769d2f051a72ba953c911abe234c204ec2cc5a35d68b4d033037fad7fba31bb92a52543f8d13d
+  curl_version: 8_1_1
+  curl_sha256: 08a948e061929645597c1ef7194e07b308b22084ff03fa7400b465e6c05149e5
+  curl_sha512: d034b1ab9c00e8a0acf7ba6c6344734945d45666b4f38394f5456fcd9b22623146a897270861b7411412ca25c912e1bbf24eb139a6dfc1a8c00d098b3b925399
 
   # renovate: datasource=git-tags extractVersion=^dejagnu-(?<version>.*)-release$ depName=git://git.savannah.gnu.org/dejagnu.git
   dejagnu_version: 1.6.3
@@ -73,9 +73,9 @@ vars:
   dejagnu_sha512: 1a737132bd912cb527e7f2fcbe70ffff8ccc8604a0ffdecff87ba2a16aeeefd800f5792aeffdbe79be6daa35cedb1c60e41002ca4aabb5370a460028191b76c4
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.savannah.gnu.org/diffutils.git
-  diffutils_version: 3.9
-  diffutils_sha256: d80d3be90a201868de83d78dad3413ad88160cc53bcc36eb9eaf7c20dbf023f1
-  diffutils_sha512: d43280cb1cb2615a8867d971467eb9a3fa037fe9a411028068036f733dab42b10d42767093cea4de71e62b2659a3ec73bd7d1a8f251befd49587e32802682d0f
+  diffutils_version: 3.10
+  diffutils_sha256: 90e5e93cc724e4ebe12ede80df1634063c7a855692685919bfe60b556c9bd09e
+  diffutils_sha512: 219d2c815a120690c6589846271e43aee5c96c61a7ee4abbef97dfcdb3d6416652ed494b417de0ab6688c4322540d48be63b5e617beb6d20530b5d55d723ccbb
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/utils/dtc/dtc.git
   dtc_version: 1.7.0
@@ -83,9 +83,9 @@ vars:
   dtc_sha512: d3ba6902a9a2f2cdbaff55f12fca3cfe4a1ec5779074a38e3d8b88097c7abc981835957e8ce72971e10c131e05fde0b1b961768e888ff96d89e42c75edb53afb
 
   # renovate: datasource=github-tags extractVersion=^v(?<version>.*)$ depName=davea42/libdwarf-code
-  dwarfutils_version: 0.6.0
-  dwarfutils_sha256: 8d6f2e67ac6fae59c7019bf41b58fa620187a136cd5977e117f15b820ffc7e75
-  dwarfutils_sha512: 839ba5e4162630ad804d76bd2aa86f35780a178dcda110106a5ee4fb27807fdf45f12e8bbb399ff53721121d0169a73335898f94218a1853116bb106dd455950
+  dwarfutils_version: 0.7.0
+  dwarfutils_sha256: 23b71829de875fa5842e49f232c8ee1a5043805749738bc61424d9abc1189f38
+  dwarfutils_sha512: 0fe027e517551d138c15695ffdebe2dfbb0e89184fc0cc93bed5c342cd1cd901dc23f6b2aa8643ec8e62808cbdc0d94389fe44438c694d19c45c6a7367e8f7af
 
   # renovate: datasource=git-tags extractVersion=^elfutils-(?<version>.*)$ depName=git://sourceware.org/git/elfutils.git
   elfutils_version: 0.189
@@ -123,9 +123,9 @@ vars:
   gettext_sha512: 61e93bc9876effd3ca1c4e64ff6ba5bd84b24951ec2cc6f40a0e3248410e60f887552f29ca1f70541fb5524f6a4e8191fed288713c3e280e18922dd5bff1a2c9
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/git/git.git
-  git_version: 2.40.1
-  git_sha256: 4893b8b98eefc9fdc4b0e7ca249e340004faa7804a433d17429e311e1fef21d2
-  git_sha512: 9ab41c64c6e666c314683bc4925535e037d43f947b8d327ff7d0379ac12899f4effcc2fe4e47b1ce652ad7140aa4f01f3b99f9cc0cf854cfeface1a5d3e1893e
+  git_version: 2.41.0
+  git_sha256: e748bafd424cfe80b212cbc6f1bbccc3a47d4862fb1eb7988877750478568040
+  git_sha512: a215bc6d89afbddd56adac901c24ea2b7f98a37bf6a6a2756893947012ffaa850e76247a3445a5ab13ab5a462f39986fec33eed086148aba5eb554dc1799fee0
 
   # official source code uses mercurial https://gmplib.org/devel/repo-usage, so falling back to a GitHub mirror,
   # renovate: datasource=github-tags extractVersion=^v(?<version>.*)$ depName=alisw/GMP
@@ -210,9 +210,9 @@ vars:
   libtool_sha512: 27acef46d9eb67203d708b57d80b853f76fa4b9c2720ff36ec161e6cdf702249e7982214ddf60bae75511aa79bc7d92aa27e3eab7ef9c0f5c040e8e42e76a385
 
   # renovate: datasource=github-tags depName=libuv/libuv
-  libuv_version: v1.44.2
-  libuv_sha256: ccfcdc968c55673c6526d8270a9c8655a806ea92468afcbcabc2b16040f03cb4
-  libuv_sha512: 91197ff9303112567bbb915bbb88058050e2ad1c048815a3b57c054635d5dc7df458b956089d785475290132236cb0edcfae830f5d749de29a9a3213eeaf0b20
+  libuv_version: v1.45.0
+  libuv_sha256: f5b07f65a1e8166e47983a7ed1f42fae0bee08f7458142170c37332fc676a748
+  libuv_sha512: 0501b8629c7ce6318684d618d8e896b8d113064cac2b0ce42e9c6ba0dc33386a621c11e7556e795bdc4c082b670675ab5947b367e100e7575e4250ad070c6cf7
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.savannah.gnu.org/m4.git
   m4_version: 1.4.19
@@ -225,9 +225,9 @@ vars:
   make_sha512: 145260cbd6a8226cef3dfef0c8baba31847beaebc7e6b65d39d02715fd4f4cab9b139b6c3772e550088d4f9ae80c6d3ed20b9a7664c693644dfb96b4cb60e67c
 
   # renovate: datasource=github-releases depName=mesonbuild/meson
-  meson_version: 1.1.0
-  meson_sha256: d9616c44cd6c53689ff8f05fc6958a693f2e17c3472a8daf83cee55dabff829f
-  meson_sha512: b8968becd1de25d8e92ecbe4c3b50694269a463430b41fcf5206f35ac952507b01f316721fb36f8c7940437e35c3588f6a4504f5b8256fa47fd9b0ceb588ae39
+  meson_version: 1.1.1
+  meson_sha256: d04b541f97ca439fb82fab7d0d480988be4bd4e62563a5ca35fadb5400727b1c
+  meson_sha512: c6259d73566d2532b87e8a23951363103f7be2aacdf120e50946273a2fed6b1602104a3ffbfda159138ac8f780d2c3e67a6fe2c8c228b73c1266775491797adb
 
   # renovate: datasource=git-tags depName=https://gitlab.inria.fr/mpc/mpc.git
   mpc_version: 1.3.1
@@ -255,14 +255,14 @@ vars:
   ncurses_sha512: 1c2efff87a82a57e57b0c60023c87bae93f6718114c8f9dc010d4c21119a2f7576d0225dab5f0a227c2cfc6fb6bdbd62728e407f35fce5bf351bb50cf9e0fd34
 
   # renovate: datasource=git-tags extractVersion=^nettle_(?<version>.*)_release.*$ depName=https://git.lysator.liu.se/nettle/nettle.git
-  nettle_version: 3.8.1
-  nettle_sha256: 364f3e2b77cd7dcde83fd7c45219c834e54b0c75e428b6f894a23d12dd41cbfe
-  nettle_sha512: a405da3438d185d96917b03b00abb9ab43e04f58f770f657f716c25d64bb258ee170a71328e74736caa7121f50c0c89d3cc840c1201d2a92cfaf1357d24bdc6a
+  nettle_version: 3.9.1
+  nettle_sha256: ccfeff981b0ca71bbd6fbcb054f407c60ffb644389a5be80d6716d5b550c6ce3
+  nettle_sha512: 5939c4b43cf9ff6c6272245b85f123c81f8f4e37089fa4f39a00a570016d837f6e706a33226e4bbfc531b02a55b2756ff312461225ed88de338a73069e031ced
 
   # renovate: datasource=git-tags extractVersion=^OpenSSL_(?<version>.*)$ versioning=loose depName=git://git.openssl.org/openssl.git
-  openssl_version: 1_1_1t
-  openssl_sha256: 8dee9b24bdb1dcbf0c3d1e9b02fb8f6bf22165e807f45adeb7c9677536859d3b
-  openssl_sha512: 628676c9c3bc1cf46083d64f61943079f97f0eefd0264042e40a85dbbd988f271bfe01cd1135d22cc3f67a298f1d078041f8f2e97b0da0d93fe172da573da18c
+  openssl_version: 1_1_1u
+  openssl_sha256: e2f8d84b523eecd06c7be7626830370300fbcc15386bf5142d72758f6963ebc6
+  openssl_sha512: d00aeb0b4c4676deff06ff95af7ac33dd683b92f972b4a8ae55cf384bb37c7ec30ab83c6c0745daf87cf1743a745fced6a347fd11fed4c548aa0953610ed4919
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/devel/pahole/pahole.git
   pahole_version: 1.25
@@ -291,9 +291,9 @@ vars:
   pkg_config_sha512: 4861ec6428fead416f5cbbbb0bbad10b9152967e481d4b0ff2eb396a9f297f552984c9bb72f6864a37dcd8fca1d9ccceda3ef18d8f121938dbe4fdf2b870fe75
 
   # renovate: datasource=github-tags extractVersion=^v(?<version>.*)$ depName=protocolbuffers/protobuf
-  protobuf_version: 23.0
-  protobuf_sha256: b29fc5fc13926f347b7a8b676ae1e63f7ccdb92c2fc8ca326bc3a883dcc168ac
-  protobuf_sha512: 6c35016a08e4c16351a5e77475928e18018ba9e2bc51975011c6836072f8fa31ca528407d8c914475e1e5ce74d33d15b6504d01d59550efffe33277291baedc3
+  protobuf_version: 23.2
+  protobuf_sha256: ddf8c9c1ffccb7e80afd183b3bd32b3b62f7cc54b106be190bf49f2bc09daab5
+  protobuf_sha512: e0404c89bf4b02ac2e895471b9244e438373a0362419ee22faab19b44a66fdb2dae5b6fe0a28a9fedde927cd83d24f883a93c8911db9429b037e97c7724ddea5
 
   # renovate: datasource=github-releases depName=protocolbuffers/protobuf-go
   protoc_gen_go_version: v1.30.0
@@ -356,9 +356,9 @@ vars:
   texinfo_sha512: 7d14f7458f2b7d0ee0b740e00a5fc2a9d61d33811aa5905d649875ec518dcb4f01be46fb0c46748f7dfe36950597a852f1473ab0648d5add225bc8f35528a8ff
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/utils/util-linux/util-linux.git
-  util_linux_version: 2.38.1
-  util_linux_sha256: 60492a19b44e6cf9a3ddff68325b333b8b52b6c59ce3ebd6a0ecaa4c5117e84f
-  util_linux_sha512: 07f11147f67dfc6c8bc766dfc83266054e6ede776feada0566b447d13276b6882ee85c6fe53e8d94a17c03332106fc0549deca3cf5f2e92dda554e9bc0551957
+  util_linux_version: 2.39.0
+  util_linux_sha256: 32b30a336cda903182ed61feb3e9b908b762a5e66fe14e43efb88d37162075cb
+  util_linux_sha512: 3d59a0f114c06be19ef7f86fca37ba5b9073823d011b3fc37997ddb00124b4505ea32903b78798a64dffbccf0ba645a692678ee845cc65a5b321824448a82a94
 
   # renovate: datasource=github-releases depName=tukaani-project/xz
   xz_version: v5.4.3

--- a/util-linux/pkg.yaml
+++ b/util-linux/pkg.yaml
@@ -3,7 +3,7 @@ dependencies:
   - stage: base
 steps:
   - sources:
-      - url: https://www.kernel.org/pub/linux/utils/util-linux/v{{ regexReplaceAll ".\\d+$" .util_linux_version "${1}" }}/util-linux-{{ .util_linux_version }}.tar.xz
+      - url: https://www.kernel.org/pub/linux/utils/util-linux/v{{ regexReplaceAll ".\\d+$" .util_linux_version "${1}" }}/util-linux-{{  regexReplaceAll "\\.0$" .util_linux_version "${1}" }}.tar.xz
         destination: util-linux.tar.xz
         sha256: "{{ .util_linux_sha256 }}"
         sha512: "{{ .util_linux_sha512 }}"


### PR DESCRIPTION
| Package | Update | Change |
|---|---|---|
| [curl/curl](https://togithub.com/curl/curl) | minor | `8_0_1` -> `8_1_2` | 
| [davea42/libdwarf-code](https://togithub.com/davea42/libdwarf-code) | minor | `0.6.0` -> `0.7.0` | 
| git://git.kernel.org/pub/scm/git/git.git | minor | `2.40.1` -> `2.41.0` | 
| git://git.kernel.org/pub/scm/utils/util-linux/util-linux.git | minor | `2.38.1` -> `2.39` | 
| git://git.openssl.org/openssl.git | patch | `1_1_1t` -> `1_1_1u` | 
| git://git.savannah.gnu.org/diffutils.git | minor | `3.9` -> `3.10` | 
| [https://git.lysator.liu.se/nettle/nettle.git](https://git.lysator.liu.se/nettle/nettle) | minor | `3.8.1` -> `3.9.1` | 
| [https://gitlab.kitware.com/cmake/cmake.git](https://gitlab.kitware.com/cmake/cmake) | patch | `3.26.3` -> `3.26.4` | 
| [libuv/libuv](https://togithub.com/libuv/libuv) | minor | `v1.44.2` -> `v1.45.0` | 
| [mesonbuild/meson](https://togithub.com/mesonbuild/meson) | patch | `1.1.0` -> `1.1.1` | 
| [protocolbuffers/protobuf](https://togithub.com/protocolbuffers/protobuf) | minor | `23.0` -> `23.2` |