### PR TITLE
chore: optimize tools image size

### DIFF
--- a/gnutls/pkg.yaml
+++ b/gnutls/pkg.yaml
@@ -30,7 +30,7 @@ steps:
 
     build:
       - |
-        make DESTDIR=/rootfs
+        make -j $(nproc) DESTDIR=/rootfs
     install:
       - |
         make DESTDIR=/rootfs install

--- a/golang/golang/pkg.yaml
+++ b/golang/golang/pkg.yaml
@@ -16,6 +16,7 @@ steps:
 
     prepare:
       - tar -xzf go.src.tar.gz --strip-components=1
+      - rm go.src.tar.gz
 
     build:
       - cd src && sh make.bash

--- a/tools/pkg.yaml
+++ b/tools/pkg.yaml
@@ -79,6 +79,9 @@ steps:
   - prepare:
       - |
         cp /pkg/files/adjust.sh ${TOOLCHAIN}/bin
+      - |
+        # clean up some files we don't ever need
+        rm -rf ${TOOLCHAIN}/man ${TOOLCHAIN}/share/doc ${TOOLCHAIN}/share/info ${TOOLCHAIN}/share/locale ${TOOLCHAIN}/share/man
 finalize:
   - from: /toolchain
     to: /toolchain


### PR DESCRIPTION
Drop stuff we don't need in the final image.

Before:

```
4.0K	./var
32K	./doc
252K	./etc
2.2M	./sbin
3.6M	./man
4.2M	./x86_64-linux-musl
36M	./include
98M	./libexec
138M	./share
163M	./bin
262M	./lib
263M	./go
969M	.
```

After:

```
4.0K	./var
32K	./doc
252K	./etc
2.2M	./sbin
3.6M	./man
4.2M	./x86_64-linux-musl
36M	./include
61M	./share
98M	./libexec
163M	./bin
239M	./go
262M	./lib
867M	.
```

So -100M (uncompressed).