### PR TITLE
chore: bump deps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
           - /usr/etc/buildkit/buildkitd.toml:/etc/buildkit/buildkitd.toml
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Unshallow
         run: |
           git fetch --prune --unshallow
@@ -51,7 +51,7 @@ jobs:
           make
       - name: Login to registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: ghcr.io
@@ -83,7 +83,7 @@ jobs:
           - /usr/etc/buildkit/buildkitd.toml:/etc/buildkit/buildkitd.toml
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Unshallow
         run: |
           git fetch --prune --unshallow

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -21,7 +21,7 @@ jobs:
           - /usr/etc/buildkit/buildkitd.toml:/etc/buildkit/buildkitd.toml
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Unshallow
         run: |
           git fetch --prune --unshallow

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ REGISTRY_AND_USERNAME := $(REGISTRY)/$(USERNAME)
 SOURCE_DATE_EPOCH ?= "1559830076"
 
 # Sync bldr image with Pkgfile
-BLDR_IMAGE := ghcr.io/siderolabs/bldr:v0.2.2
+BLDR_IMAGE := ghcr.io/siderolabs/bldr:v0.2.3
 BLDR ?= docker run --rm --volume $(PWD):/tools --entrypoint=/bldr \
 	$(BLDR_IMAGE) graph --root=/tools
 

--- a/Pkgfile
+++ b/Pkgfile
@@ -1,11 +1,11 @@
-# syntax = ghcr.io/siderolabs/bldr:v0.2.2
+# syntax = ghcr.io/siderolabs/bldr:v0.2.3
 
 # Sync bldr image with Makefile
 
 format: v1alpha2
 
 vars:
-  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v0.8.0-5-g0048734
+  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v0.8.0-10-gfee0af0
 
   # renovate: datasource=github-releases depName=abseil/abseil-cpp
   abseil_version: 20230802.1
@@ -209,9 +209,9 @@ vars:
   make_sha512: 145260cbd6a8226cef3dfef0c8baba31847beaebc7e6b65d39d02715fd4f4cab9b139b6c3772e550088d4f9ae80c6d3ed20b9a7664c693644dfb96b4cb60e67c
 
   # renovate: datasource=github-releases depName=mesonbuild/meson
-  meson_version: 1.2.2
-  meson_sha256: 4a0f04de331fbc7af3b802a844fc8838f4ccd1ded1e792ba4f8f2faf8c5fe4d6
-  meson_sha512: 8dde3235f31862953e2f4db2527e441dfa9413b5f7545c85949ebc0f3b58819307ca124bf04d481d6f1425d6a4c93051239a659554322af893c97b651379fa86
+  meson_version: 1.2.3
+  meson_sha256: 4533a43c34548edd1f63a276a42690fce15bde9409bcf20c4b8fa3d7e4d7cac1
+  meson_sha512: cdcadc731effc1ffb2de98b795ba37955f934ed9b54b9f7f3ac5fe96ab33268d4de4fce734a4c2ef7d2ecc5051616df127e1f8665e197ff954310bf1483b81fc
 
   # renovate: datasource=git-tags depName=https://gitlab.inria.fr/mpc/mpc.git
   mpc_version: 1.3.1
@@ -244,9 +244,9 @@ vars:
   nettle_sha512: 5939c4b43cf9ff6c6272245b85f123c81f8f4e37089fa4f39a00a570016d837f6e706a33226e4bbfc531b02a55b2756ff312461225ed88de338a73069e031ced
 
   # renovate: datasource=git-tags extractVersion=^openssl-(?<version>.*)$ depName=git://git.openssl.org/openssl.git
-  openssl_version: 3.1.3
-  openssl_sha256: f0316a2ebd89e7f2352976445458689f80302093788c466692fb2a188b2eacf6
-  openssl_sha512: 2388eaa8e99acf1e8af4691a645b9b9af456900c74959e82d4cb02808301e11dcfecc86954a922262b16fa4b664b459894d133ab7d35ec82e1633a33194b7b20
+  openssl_version: 3.1.4
+  openssl_sha256: 840af5366ab9b522bde525826be3ef0fb0af81c6a9ebd84caa600fea1731eee3
+  openssl_sha512: a69df4a018f57dee7d8a57c8003a6869eba11f1eaa394518976642a993780d0de3326019e92dea4c679c6c581fef568ea616ec541afc0792800359c606dffcd2
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/devel/pahole/pahole.git
   pahole_version: 1.25
@@ -285,9 +285,9 @@ vars:
   protoc_gen_go_sha512: edcd48b8cee045d69fd8a649a7af8041b6fa71183cfdb6dde6369602d496745e87ccb3a53f0847ed23f4052114bd13d95b46af235f95e3930804951d5e7356b2
 
   # renovate: datasource=github-tags depName=grpc/grpc-go
-  protoc_gen_go_grpc_version: v1.58.3
-  protoc_gen_go_grpc_sha256: d56288406a7b9ec60c5d8819ce88e17ca97947d5eb99c25bd0750eb1f1d153d4
-  protoc_gen_go_grpc_sha512: 64837162c2d201da35224ada3e3f9ab661068d9bc13bac0e5d8382bc731dd298bda73efee4354f5ce99534b7d235967ab123bce64aeebe86f87257922370b46d
+  protoc_gen_go_grpc_version: v1.59.0
+  protoc_gen_go_grpc_sha256: 0f951688030fdc9a82accb440222ff068440e59bdc44a82d86150cc4cddf1aed
+  protoc_gen_go_grpc_sha512: 1ce4e47777cb2c16933069845fe46c3d2eabe1986be04103c49eb7e9ade1a26a933073019820c41e36082d02fb24e7c3d3ab7db7f4af7c1784b0b9796f312e94
 
   # renovate: datasource=github-tags extractVersion=^v(?<version>.*)$ depName=python/cpython
   python_version: 3.11.5
@@ -330,9 +330,9 @@ vars:
   tcl_sha512: 23cd8e7673ac19594ec3ca70c6de4c471ce0a0ca7694bd232a7d04d280f9cb1f7e0b677411b0dbcc8c6ea61bf9cd9a59a86f0b07bab5f0a3c7bf46becc9cd73c
 
   # renovate: datasource=git-tags extractVersion=^texinfo-(?<version>.*)$ depName=git://git.savannah.gnu.org/texinfo.git
-  texinfo_version: 7.0.3
-  texinfo_sha256: 74b420d09d7f528e84f97aa330f0dd69a98a6053e7a4e01767eed115038807bf
-  texinfo_sha512: 7d14f7458f2b7d0ee0b740e00a5fc2a9d61d33811aa5905d649875ec518dcb4f01be46fb0c46748f7dfe36950597a852f1473ab0648d5add225bc8f35528a8ff
+  texinfo_version: 7.1
+  texinfo_sha256: deeec9f19f159e046fdf8ad22231981806dac332cc372f1c763504ad82b30953
+  texinfo_sha512: ceab03e8422d800b08c7b44e8263b0a1f35bb7758d83a81136df6f3304a14daecda98a12a282afb85406d2ca2f665b2295e10b6f4064156ea1285d80d5d355db
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/utils/util-linux/util-linux.git
   util_linux_version: 2.39.2


### PR DESCRIPTION
- bump bldr to v0.2.3
- bump actions/checkout to v4
- bump docker/login-action to v3
- bump meson to v1.2.3
- bump openssl to v3.1.4
- bump protoc_gen_go_grpc to v1.59.0
- bump texinfo to v7.1