### PR TITLE
feat: update Go to 1.20.11

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -129,9 +129,9 @@ vars:
   gmp_sha512: c99be0950a1d05a0297d65641dd35b75b74466f7bf03c9e8a99895a3b2f9a0856cd17887738fa51cf7499781b65c049769271cbcb77d057d2e9f1ec52e07dd84
 
   # renovate: datasource=github-tags extractVersion=^go(?<version>.*)$ depName=golang/go
-  golang_version: 1.20.10
-  golang_sha256: 72d2f51805c47150066c103754c75fddb2c19d48c9219fa33d1e46696c841dbb
-  golang_sha512: 1c6304abb8a7847cedb634380d43fcbf2b206f0e6af99e915b4735b4c5f9dfc08a01db6d41edaed91a2a8140fcd886343d39465bd6fb53bd37be0a7f41dc6525
+  golang_version: 1.20.11
+  golang_sha256: d355c5ae3a8f7763c9ec9dc25153aae373958cbcb60dd09e91a8b56c7621b2fc
+  golang_sha512: d89fb9ecd9fe394b7f6b9a0ad98db2f9401bec203d64cc5c301d3678f6a74524bae85a9ece31ad2ea66a3ffec90f35cb30e600e0c910bcc6010ad36b501c5c37
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.savannah.gnu.org/gperf.git
   gperf_version: 3.1


### PR DESCRIPTION
See https://github.com/golang/go/issues?q=milestone%3AGo1.20.11+label%3ACherryPickApproved