### PR TITLE
backport: feat: update Go to 1.21.5

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -129,9 +129,9 @@ vars:
   gmp_sha512: c99be0950a1d05a0297d65641dd35b75b74466f7bf03c9e8a99895a3b2f9a0856cd17887738fa51cf7499781b65c049769271cbcb77d057d2e9f1ec52e07dd84
 
   # renovate: datasource=github-tags extractVersion=^go(?<version>.*)$ depName=golang/go
-  golang_version: 1.21.4
-  golang_sha256: 47b26a83d2b65a3c1c1bcace273b69bee49a7a7b5168a7604ded3d26a37bd787
-  golang_sha512: a6019d51876d7705f7737cddae748f9df3b4e1b40d678094465d2e81b18a4a99b93c3979d318d6c0c6d314e44554894105d07665b7d81acbbfd80203d3ed95bc
+  golang_version: 1.21.5
+  golang_sha256: 285cbbdf4b6e6e62ed58f370f3f6d8c30825d6e56c5853c66d3c23bcdb09db19
+  golang_sha512: c064b7cb3c47d8fb99fc181a3cddf327a4b7a8c6af39a8ac568e9d74cd44903141680903ca48673bb02a7a159cce4f32a94f3b37fc65a9549d3518ad7c731fa3
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.savannah.gnu.org/gperf.git
   gperf_version: 3.1
@@ -265,9 +265,9 @@ vars:
 
   # perl uses even numbered minor versions for stable releases - https://www.cpan.org/src/README.html
   # renovate: datasource=github-tags extractVersion=^v(?<version>.*)$ depName=Perl/perl5
-  perl_version: 5.38.1
-  perl_sha256: 6a82c7930563086e78cb84d9c265e6b212ee65d509d19eedcd23ab8c1ba3f046
-  perl_sha512: 720b2c2707f219509e652bc3d80f9ce82bec85f882dee9ff88b6bc5183064d66333651830daeb92a6e96bbe5d9d48581ab8496ce9427f8db6103fc438e2c05db
+  perl_version: 5.38.2
+  perl_sha256: d91115e90b896520e83d4de6b52f8254ef2b70a8d545ffab33200ea9f1cf29e8
+  perl_sha512: 0ca51e447c7a18639627c281a1c7ae6662c773745ea3c86bede46336d5514ecc97ded2c61166e1ac15635581489dc596368907aa3a775b34db225b76d7402d10
 
   # renovate: datasource=git-tags extractVersion=^pkg-config-(?<version>.*)$ depName=https://gitlab.freedesktop.org/pkg-config/pkg-config.git
   pkg_config_version: 0.29.2


### PR DESCRIPTION
See https://go.dev/doc/devel/release#go1.21.5

Signed-off-by: Andrey Smirnov <andrey.smirnov@siderolabs.com>
(cherry picked from commit 1659d82e78511522e2820efccb892235d6d7b279)