### PR TITLE
backport: feat: update Go to 1.21.6

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -129,9 +129,9 @@ vars:
   gmp_sha512: c99be0950a1d05a0297d65641dd35b75b74466f7bf03c9e8a99895a3b2f9a0856cd17887738fa51cf7499781b65c049769271cbcb77d057d2e9f1ec52e07dd84
 
   # renovate: datasource=github-tags extractVersion=^go(?<version>.*)$ depName=golang/go
-  golang_version: 1.21.5
-  golang_sha256: 285cbbdf4b6e6e62ed58f370f3f6d8c30825d6e56c5853c66d3c23bcdb09db19
-  golang_sha512: c064b7cb3c47d8fb99fc181a3cddf327a4b7a8c6af39a8ac568e9d74cd44903141680903ca48673bb02a7a159cce4f32a94f3b37fc65a9549d3518ad7c731fa3
+  golang_version: 1.21.6
+  golang_sha256: 124926a62e45f78daabbaedb9c011d97633186a33c238ffc1e25320c02046248
+  golang_sha512: 8472c1c6c3fae9fecfb512a16f18ed531c04c087429a75086b9999069330c1b1e4a01a30c6561b5092169144cbc0d787ec2f5f4a50dfc4f79e74398f16423cfd
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.savannah.gnu.org/gperf.git
   gperf_version: 3.1


### PR DESCRIPTION
See https://go.dev/doc/devel/release#go1.21.minor

Signed-off-by: Andrey Smirnov <andrey.smirnov@siderolabs.com>
(cherry picked from commit a80a2aa0307d90f07c8a239459191a3f68cdd5d3)