### PR TITLE
feat: update Go to 1.20.13

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -129,9 +129,9 @@ vars:
   gmp_sha512: c99be0950a1d05a0297d65641dd35b75b74466f7bf03c9e8a99895a3b2f9a0856cd17887738fa51cf7499781b65c049769271cbcb77d057d2e9f1ec52e07dd84
 
   # renovate: datasource=github-tags extractVersion=^go(?<version>.*)$ depName=golang/go
-  golang_version: 1.20.11
-  golang_sha256: d355c5ae3a8f7763c9ec9dc25153aae373958cbcb60dd09e91a8b56c7621b2fc
-  golang_sha512: d89fb9ecd9fe394b7f6b9a0ad98db2f9401bec203d64cc5c301d3678f6a74524bae85a9ece31ad2ea66a3ffec90f35cb30e600e0c910bcc6010ad36b501c5c37
+  golang_version: 1.20.13
+  golang_sha256: 0fe745c530f2f1d67193af3c5ea25246be077989ec5178df266e975f3532449e
+  golang_sha512: 87cf8c5e201526c3f44a6b1845a7de3f8a02d054f8689d10c84d5da0d286390b54dc23fc22f82e050d792e1d10c69049691a0d46b198b3fdd2e80087b38f5f06
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.savannah.gnu.org/gperf.git
   gperf_version: 3.1


### PR DESCRIPTION
This is the latest Go 1.20.x (for Talos 1.5.x).