### PR TITLE
feat: update Go to 1.22.1

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -129,9 +129,9 @@ vars:
   gmp_sha512: c99be0950a1d05a0297d65641dd35b75b74466f7bf03c9e8a99895a3b2f9a0856cd17887738fa51cf7499781b65c049769271cbcb77d057d2e9f1ec52e07dd84
 
   # renovate: datasource=github-tags extractVersion=^go(?<version>.*)$ depName=golang/go
-  golang_version: 1.22.0
-  golang_sha256: 4d196c3d41a0d6c1dfc64d04e3cc1f608b0c436bd87b7060ce3e23234e1f4d5c
-  golang_sha512: f47fdac3281463757b3db9f6ab747f86ed7263beed52c820ec2571375a578034df02c0b76912c19fab3a58df3b04d79b6aae084163d1d5847c907aeb30b936e3
+  golang_version: 1.22.1
+  golang_sha256: 79c9b91d7f109515a25fc3ecdaad125d67e6bdb54f6d4d98580f46799caea321
+  golang_sha512: 627530c3fa2ea872478e1df8ee20db2ddc3c94581fff4e66bda21ca45a643e9915f97115401f79667cd7e856ccca1b40a842f4c0b509a472c75696e3bdb3a908
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.savannah.gnu.org/gperf.git
   gperf_version: 3.1


### PR DESCRIPTION
crypto/x509: Verify panics on certificates with an unknown public key algorithm

Verifying a certificate chain which contains a certificate with an unknown public key algorithm will cause Certificate.Verify to panic.

This affects all crypto/tls clients, and servers that set Config.ClientAuth to VerifyClientCertIfGiven or RequireAndVerifyClientCert. The default behavior is for TLS servers to not verify client certificates.

Thanks to John Howard (Google) for reporting this issue.

This is CVE-2024-24783 and Go issue https://go.dev/issue/65390.

net/http: memory exhaustion in Request.ParseMultipartForm

When parsing a multipart form (either explicitly with Request.ParseMultipartForm or implicitly with Request.FormValue, Request.PostFormValue, or Request.FormFile), limits on the total size of the parsed form were not applied to the memory consumed while reading a single form line. This permitted a maliciously crafted input containing very long lines to cause allocation of arbitrarily large amounts of memory, potentially leading to memory exhaustion.

ParseMultipartForm now correctly limits the maximum size of form lines.

Thanks to Bartek Nowotarski for reporting this issue.

This is CVE-2023-45290 and Go issue https://go.dev/issue/65383.

net/http, net/http/cookiejar: incorrect forwarding of sensitive headers and cookies on HTTP redirect

When following an HTTP redirect to a domain which is not a subdomain match or exact match of the initial domain, an http.Client does not forward sensitive headers such as "Authorization" or "Cookie". For example, a redirect from foo.com to www.foo.com will forward the Authorization header, but a redirect to bar.com will not.

A maliciously crafted HTTP redirect could cause sensitive headers to be unexpectedly forwarded.

Thanks to Juho Nurminen of Mattermost for reporting this issue.

This is CVE-2023-45289 and Go issue https://go.dev/issue/65065.

html/template: errors returned from MarshalJSON methods may break template escaping

If errors returned from MarshalJSON methods contain user controlled data, they may be used to break the contextual auto-escaping behavior of the html/template package, allowing for subsequent actions to inject unexpected content into templates.

Thanks to RyotaK (https://ryotak.net) for reporting this issue.

This is CVE-2024-24785 and Go issue https://go.dev/issue/65697.

net/mail: comments in display names are incorrectly handled

The ParseAddressList function incorrectly handles comments (text within parentheses) within display names. Since this is a misalignment with conforming address parsers, it can result in different trust decisions being made by programs using different parsers.

Thanks to Juho Nurminen of Mattermost and Slonser (https://github.com/Slonser) for reporting this issue.

This is CVE-2024-24784 and Go issue https://go.dev/issue/65083.