### PR TITLE
chore: bump systemd

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -314,10 +314,10 @@ vars:
   swig_sha256: 2af08aced8fcd65cdb5cc62426768914bedc735b1c250325203716f78e39ac9b
   swig_sha512: 1cea1918455a75ebc9b2653dd1715bd5dcd974554955f324295c6a6f14c0a715651b221b85fad4a8af5197e0c75bfe7b590bc6ba7178c26245fbbd9a7e110100
 
-  # renovate: datasource=github-releases depName=systemd/systemd
-  systemd_version: v254
-  systemd_sha256: 244da7605800a358915e4b45d079b0b89364be35da4bc8d849821e67bac0ce62
-  systemd_sha512: 84b4d16980fe2e64d5c3c95b9b4fbaad1076f368f493fdd745cbafbe7ce825293384f5fa0b6360ba8188da23c4575e87402fb666a3b71f84ff8b323aba0c07ff
+  # renovate: datasource=github-releases extractVersion=^v(?<version>.*)$ depName=systemd/systemd
+  systemd_version: 255
+  systemd_sha256: 28854ffb2cb5f9e07fcbdbaf1e03a80b3462a12edeef84893ca2f37b22e4491e
+  systemd_sha512: 51728de604c2169d8643718ac72acb8f70f613cfcca9e9abb7dac519f291fa26a16d48f24cae6897356319096cfe8f4d9377743e7870127374f98d432e0c557c
 
   # renovate: datasource=git-tags extractVersion=^release_(?<version>.*)$ depName=git://git.savannah.gnu.org/tar.git
   tar_version: 1_34

--- a/sd-boot/pkg.yaml
+++ b/sd-boot/pkg.yaml
@@ -16,7 +16,7 @@ dependencies:
   - stage: util-linux
 steps:
   - sources:
-      - url: https://github.com/systemd/systemd/archive/refs/tags/{{ .systemd_version }}.tar.gz
+      - url: https://github.com/systemd/systemd/archive/refs/tags/v{{ .systemd_version }}.tar.gz
         destination: systemd.tar.gz
         sha256: "{{ .systemd_sha256 }}"
         sha512: "{{ .systemd_sha512 }}"


### PR DESCRIPTION
Bump systemd to `255` and fix renovate matcher for systemd.