### PR TITLE
fix: xz vulnerability

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -5,7 +5,7 @@
 format: v1alpha2
 
 vars:
-  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v0.11.0-alpha.0-5-g33d73a0
+  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v0.11.0
 
   # renovate: datasource=github-releases depName=abseil/abseil-cpp
   abseil_version: 20240116.1
@@ -340,9 +340,10 @@ vars:
   util_linux_sha512: a2de1672f06ca5d2d431db1265a8499808770c3781019ec4a3a40170df4685826d8e3ca120841dcc5df4681ca8c935a993317bd0dc70465b21bf8e0efef65afa
 
   # renovate: datasource=github-releases depName=tukaani-project/xz
-  xz_version: v5.6.1
-  xz_sha256: f334777310ca3ae9ba07206d78ed286a655aa3f44eec27854f740c26b2cd2ed0
-  xz_sha512: a8b6d2e58eb61609a64b182e868c47aaf722d34f87bad3a9598c94ad96fb3357477959a95bb215c1dac59b8c84453cf00dc23669d13358f4aeb5123526f741f2
+  # NOTE: using 5.4.5 the version debian downgraded to. Ref: https://www.openwall.com/lists/oss-security/2024/03/29/4
+  xz_version: v5.4.5
+  xz_sha256: da9dec6c12cf2ecf269c31ab65b5de18e8e52b96f35d5bcd08c12b43e6878803
+  xz_sha512: 5cbc3b5bb35a9f5773ad657788fe77013471e3b621c5a8149deb7389d48535926e5bed103456fcfe5ecb044b236b1055b03938a6cc877cfc749372b899fc79e5
 
   # renovate: datasource=github-tags extractVersion=^v(?<version>.*)$ depName=madler/zlib
   zlib_version: 1.3.1

--- a/xz/pkg.yaml
+++ b/xz/pkg.yaml
@@ -8,7 +8,8 @@ dependencies:
   - stage: libtool
 steps:
   - sources:
-      - url: https://github.com/tukaani-project/xz/releases/download/{{ .xz_version }}/xz-{{ .xz_version | replace "v" "" }}.tar.xz
+      # - url: https://github.com/tukaani-project/xz/releases/download/{{ .xz_version }}/xz-{{ .xz_version | replace "v" "" }}.tar.xz
+      - url: https://src.fedoraproject.org/lookaside/pkgs/xz/xz-5.4.5.tar.xz/sha512/5cbc3b5bb35a9f5773ad657788fe77013471e3b621c5a8149deb7389d48535926e5bed103456fcfe5ecb044b236b1055b03938a6cc877cfc749372b899fc79e5/xz-5.4.5.tar.xz
         destination: xz.tar.xz
         sha256: "{{ .xz_sha256 }}"
         sha512: "{{ .xz_sha512 }}"


### PR DESCRIPTION
This downgrades xz version to `v5.4.5` which is the same version other distros have downgraded to.

Sidero repos are not affected, just downgrading as a safe precaution.

Ref: https://www.openwall.com/lists/oss-security/2024/03/29/4

Also pulls in the latest stable toolchain.