### PR TITLE
feat: add fakeroot as a build dependency

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -97,6 +97,11 @@ vars:
   file_sha256: 28c01a5ef1a127ef71758222ca019ba6c6bfa4a8fe20c2b525ce75943ee9da3c
   file_sha512: fdd4c5d13d5ea1d25686c76d8ebc3252c54040c4871e3f0f623c4548b3841795d4e36050292a9453eedf0fbf932573890e9d6ac9fa63ccf577215598ae84b9ea
 
+  # renovate: datasource=git-tags extractVersion=^upstream/(?<version>.*)$ depName=git://salsa.debian.org/clint/fakeroot.git
+  fakeroot_version: 1.36
+  fakeroot_sha256: 5128dd5df59955d60453aea1817d2f31c29ffb8b8addcc5d7e200460278a6b0a
+  fakeroot_sha512: 1ff4cfe8bd4637652027b9e994ed39bf9885d6ea1608050ff21343dc2977c0607c2af235f51376e086ec88ee975da5cb7115a9888ee9437c927426a2eac1bf4b
+
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.savannah.gnu.org/findutils.git
   findutils_version: 4.10.0
   findutils_sha256: 1387e0b67ff247d2abde998f90dfbf70c1491391a59ddfecb8ae698789f0a4f5

--- a/fakeroot/patches/fakeroot-no64.patch
+++ b/fakeroot/patches/fakeroot-no64.patch
@@ -1,0 +1,20 @@
+This patch fixes building with musl libc
+
+https://github.com/void-linux/void-packages/blob/e3ff6da0aa9f378356cec4184580025ddae771de/srcpkgs/fakeroot/patches/fakeroot-no64.patch
+
+--- a/libfakeroot.c
++++ b/libfakeroot.c
+@@ -81,12 +81,14 @@
+ #define SEND_STAT64(a,b,c) send_stat64(a,b,c)
+ #define SEND_GET_STAT(a,b) send_get_stat(a,b)
+ #define SEND_GET_STAT64(a,b) send_get_stat64(a,b)
++#define SEND_GET_XATTR(a,b,c) send_get_xattr(a,b,c)
+ #define SEND_GET_XATTR64(a,b,c) send_get_xattr64(a,b,c)
+ #else
+ #define SEND_STAT(a,b,c) send_stat(a,b)
+ #define SEND_STAT64(a,b,c) send_stat64(a,b)
+ #define SEND_GET_STAT(a,b) send_get_stat(a)
+ #define SEND_GET_STAT64(a,b) send_get_stat64(a)
++#define SEND_GET_XATTR(a,b,c) send_get_xattr(a,b)
+ #define SEND_GET_XATTR64(a,b,c) send_get_xattr64(a,b)
+ #endif

--- a/fakeroot/patches/fix-shell.patch
+++ b/fakeroot/patches/fix-shell.patch
@@ -1,0 +1,14 @@
+Description: Fix shell in fakeroot.in
+ Use /bin/sh instead of @SHELL@ in fakeroot.in
+Author: Juan Picca <jumapico@gmail.com>
+Source: Debian
+Last-Update: 2024-08-22 by Dmitrii Sharshakov
+---
+--- a/scripts/fakeroot.in
++++ b/scripts/fakeroot.in
+@@ -1,4 +1,4 @@
+-#!@SHELL@
++#!/toolchain/bin/bash
+ 
+ # This script first starts faked (the daemon), and then it will run
+ # the requested program with fake root privileges.

--- a/fakeroot/patches/no-docs.patch
+++ b/fakeroot/patches/no-docs.patch
@@ -1,0 +1,12 @@
+diff --git a/Makefile.am b/Makefile.am
+index 46f01eb..4c10cfa 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -1,6 +1,6 @@
+ AUTOMAKE_OPTIONS=foreign
+ ACLOCAL_AMFLAGS = -I build-aux
+-SUBDIRS=doc scripts test
++SUBDIRS=scripts test
+ 
+ noinst_LTLIBRARIES = libcommunicate.la libmacosx.la libfakeroot_time64.la
+ libcommunicate_la_SOURCES = communicate.c

--- a/fakeroot/pkg.yaml
+++ b/fakeroot/pkg.yaml
@@ -1,0 +1,35 @@
+name: fakeroot
+dependencies:
+  - stage: base
+  - stage: patch
+  - stage: autoconf
+  - stage: automake
+  - stage: libtool
+  - stage: libcap
+steps:
+  - sources:
+      - url: https://salsa.debian.org/clint/fakeroot/-/archive/upstream/{{ .fakeroot_version }}/fakeroot-upstream-{{ .fakeroot_version }}.tar.gz
+        destination: fakeroot.tar.gz
+        sha256: "{{ .fakeroot_sha256 }}"
+        sha512: "{{ .fakeroot_sha512 }}"
+    prepare:
+      - |
+        tar -xzvf fakeroot.tar.gz --strip-components=1
+
+        patch -p1 < /pkg/patches/fix-shell.patch
+        patch -p1 < /pkg/patches/no-docs.patch
+        patch -p1 < /pkg/patches/fakeroot-no64.patch
+
+        autoreconf -vif
+        ./configure \
+            --prefix=${TOOLCHAIN} \
+            CFLAGS="${CFLAGS} -fPIC"
+    build:
+      - |
+        make -j $(nproc)
+    install:
+      - |
+        make install DESTDIR=/rootfs PREFIX=/toolchain
+finalize:
+  - from: /rootfs
+    to: /

--- a/tools/pkg.yaml
+++ b/tools/pkg.yaml
@@ -23,6 +23,7 @@ dependencies:
   - stage: elfutils
   - stage: expat
   - stage: expect
+  - stage: fakeroot
   - stage: file
   - stage: findutils
   - stage: flex


### PR DESCRIPTION
fakeroot helps us set SELinux labels which do not exist on host or work on non-SELinux hosts.