### PR TITLE
fix: do not install anything to /usr/lib64

### DIFF
--- a/pahole/pkg.yaml
+++ b/pahole/pkg.yaml
@@ -42,6 +42,9 @@ steps:
         cd build
         make DESTDIR=/rootfs install
         rm -rf /rootfs/usr/share
+        mkdir -p /rootfs/usr/lib
+        mv /rootfs/usr/lib64/* /rootfs/usr/lib/
+        rm -r /rootfs/usr/lib64
 finalize:
   - from: /rootfs
     to: /

--- a/protobuf/pkg.yaml
+++ b/protobuf/pkg.yaml
@@ -19,7 +19,7 @@ steps:
       - |
         tar -xzf protobuf.tar.gz --strip-components=1
 
-        cmake . -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_ABSL_PROVIDER=package -DCMAKE_INSTALL_PREFIX=/usr
+        cmake . -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_ABSL_PROVIDER=package -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBDIR=lib
     build:
       - |
         make -j $(nproc)


### PR DESCRIPTION
Avoid breaking multilib symlinks

Signed-off-by: Dmitry Sharshakov <dmitry.sharshakov@siderolabs.com>
