### PR TITLE
fix: install policycoreutils under correct prefix

### DIFF
--- a/policycoreutils/pkg.yaml
+++ b/policycoreutils/pkg.yaml
@@ -23,7 +23,7 @@ steps:
         make -j $(nproc) SUBDIRS=setfiles FTS_LDLIBS="-l:libfts.a -lpcre2-8"
     install:
       - |
-        make install DESTDIR=/rootfs/usr SBINDIR=/usr/bin SUBDIRS=setfiles
+        make install DESTDIR=/rootfs SBINDIR=/usr/bin SUBDIRS=setfiles
 finalize:
   - from: /rootfs
     to: /


### PR DESCRIPTION
Fix prefix to install to PATH

Signed-off-by: Dmitry Sharshakov <dmitry.sharshakov@siderolabs.com>
