### PR TITLE
feat: Add squashfs-tools-ng to tools image

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -58,6 +58,7 @@
         {
             "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.?(?<patch>\\d+)?$",
             "matchPackageNames": [
+                "AgentD/squashfs-tools-ng",
                 "golang/go",
                 "mirror/ncurses",
                 "PCRE2Project/pcre2",

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -12,6 +12,7 @@ spec:
     - tools-openssl
     - tools-pcre2
     - tools-squashfs-tools
+    - tools-squashfs-tools-ng
     - tools-tar
     - tools-util-linux
     - tools-xz
@@ -23,6 +24,7 @@ kind: common.Renovate
 spec:
   packageRules:
     - matchPackageNames:
+        - AgentD/squashfs-tools-ng
         - golang/go
         - mirror/ncurses
         - PCRE2Project/pcre2

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ TARGETS += tools-libsepol
 TARGETS += tools-openssl
 TARGETS += tools-pcre2
 TARGETS += tools-squashfs-tools
+TARGETS += tools-squashfs-tools-ng
 TARGETS += tools-tar
 TARGETS += tools-util-linux
 TARGETS += tools-xz

--- a/Pkgfile
+++ b/Pkgfile
@@ -356,6 +356,11 @@ vars:
   squashfs_tools_sha256: 94201754b36121a9f022a190c75f718441df15402df32c2b520ca331a107511c
   squashfs_tools_sha512: 10e8a4b1e2327e062aef4f85860e76ebcd7a29e4c19e152ff7edec4a38316982b5bcfde4ab69da6bcb931258d264c2b6cb40cb5f635f9e6f6eba1ed5976267cb
 
+  # renovate: datasource=github-tags depName=AgentD/squashfs-tools-ng
+  squashfs_tools_ng_version: v1.3.2
+  squashfs_tools_ng_sha256: 21f40dc82f69b721e92bfc539e47bfb8581753f8de492c877c59737ce2e3bf0f
+  squashfs_tools_ng_sha512: 21d080718f5b68b2c3ae12899b04d9eb51644d62f2cff32261f1aedc1919f9bc15b37e8bc723db54f24ed95914db8ee6e43c544dcf375a6c002ff615d15dc6d1
+
   # renovate: datasource=github-tags depName=swig/swig
   swig_version: v4.2.1
   swig_sha256: 8895878b9215612e73611203dc8f5232c626e4d07ffc4532922f375518f067ca

--- a/tools-squashfs-tools-ng/pkg.yaml
+++ b/tools-squashfs-tools-ng/pkg.yaml
@@ -1,0 +1,41 @@
+name: tools-squashfs-tools-ng
+variant: scratch
+dependencies:
+  - stage: base
+  - stage: autoconf
+  - stage: automake
+  - stage: libtool
+  - stage: pkg-config
+  - stage: tools-libselinux
+  - stage: tools-xz
+  - stage: tools-zlib
+  - stage: tools-zstd
+steps:
+  - sources:
+      - url: https://github.com/AgentD/squashfs-tools-ng/archive/refs/tags/{{ .squashfs_tools_ng_version }}.tar.gz
+        destination: squashfs-tools-ng.tar.gz
+        sha256: "{{ .squashfs_tools_ng_sha256 }}"
+        sha512: "{{ .squashfs_tools_ng_sha512 }}"
+    prepare:
+      - |
+        mkdir -p squashfs-tools-ng build
+
+        tar -xf squashfs-tools-ng.tar.gz --strip-components=1 -C squashfs-tools-ng
+        cd squashfs-tools-ng
+        ./autogen.sh
+        cd ../build
+        ../squashfs-tools-ng/configure \
+          --prefix=/usr
+    build:
+      - |
+        make -C build -j $(nproc)
+    install:
+      - |
+        make -C build DESTDIR=/rootfs install
+        rm -rf /rootfs/usr/share/man
+    test:
+      - |
+        fhs-validator /rootfs
+finalize:
+  - from: /rootfs
+    to: /

--- a/tools/pkg.yaml
+++ b/tools/pkg.yaml
@@ -79,6 +79,7 @@ dependencies:
   - stage: tools-openssl
   - stage: tools-pcre2
   - stage: tools-squashfs-tools
+  - stage: tools-squashfs-tools-ng
   - stage: tools-tar
   - stage: tools-util-linux
   - stage: tools-xz


### PR DESCRIPTION
Provides alternatives to mksquashfs, unsquashfs which make it easier to perform SELinux labeling when building images inside unprivileged containers.