### PR TITLE
chore: update toolchain to the latest version

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -5,7 +5,7 @@
 format: v1alpha2
 
 vars:
-  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v1.10.0
+  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v1.11.0-alpha.0
 
   # renovate: datasource=github-releases depName=abseil/abseil-cpp
   abseil_version: 20250127.1


### PR DESCRIPTION
This allows to add a parallel Go 1.23 tooclhain.