### PR TITLE
chore: update toolchain to the latest version

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -5,7 +5,7 @@
 format: v1alpha2
 
 vars:
-  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v1.10.0
+  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v1.10.0-1-g0c4c53b
 
   # renovate: datasource=github-releases depName=abseil/abseil-cpp
   abseil_version: 20250127.1


### PR DESCRIPTION
This allows to add a parallel Go 1.23 tooclhain.

Signed-off-by: Andrey Smirnov <andrey.smirnov@siderolabs.com>
(cherry picked from commit c96a4e671e378f80f161e45942f80b10adfd562d)

Backports PR #449 