### PR TITLE
feat: update toolchain to 1.11.0

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -5,7 +5,7 @@
 format: v1alpha2
 
 vars:
-  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v1.11.0-alpha.0-7-g149a96f
+  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v1.11.0
 
   # stick to whatever version protobuf requires, see https://github.com/protocolbuffers/protobuf/blob/33d0cd03571aca25adf11d3a62add1d52d1cc27d/cmake/dependencies.cmake#L15
   # renovate: datasource=github-releases depName=abseil/abseil-cpp


### PR DESCRIPTION
Preparing to cut tools 1.11.0, no changes to toolchain (just a tagged release).