### PR TITLE
feat: update toolchain for new Go and Linux headers

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -5,7 +5,7 @@
 format: v1alpha2
 
 vars:
-  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v1.12.0-alpha.0
+  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v1.12.0-alpha.0-2-ga7a522d
 
   # renovate: datasource=github-tags depName=argp-standalone/argp-standalone
   argp_standalone_version: 1.5.0


### PR DESCRIPTION
Go 1.25, Linux headers 6.15.11

Signed-off-by: Dmitrii Sharshakov <dmitry.sharshakov@siderolabs.com>
