### PR TITLE
chore: update OpenSSL to 3.6.2

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -248,9 +248,9 @@ vars:
   ninja_sha512: c0b401b4db91a2eea01a474ee979b2c6f1daa97b4c8d1f856871ce5f6d567c4b26d6246bc57e2a5f914329302abcd9c00ab0d4394a25f2ad502b6b00a07903d2
 
   # renovate: datasource=github-releases extractVersion=^openssl-(?<version>.*)$ depName=openssl/openssl
-  openssl_version: 3.6.1
-  openssl_sha256: b1bfedcd5b289ff22aee87c9d600f515767ebf45f77168cb6d64f231f518a82e
-  openssl_sha512: 492cd2e0a7506e085d9840a929ead994390409a35c24e47e0cf44987920711b61f1513f21b7eee50e56f226b26cd654cda6dbd1f6e439563a93a8f0e530fefb5
+  openssl_version: 3.6.2
+  openssl_sha256: aaf51a1fe064384f811daeaeb4ec4dce7340ec8bd893027eee676af31e83a04f
+  openssl_sha512: 46549ed4d6b0160adfa3e1406bc16f3083a7f3c85bdda289c1dbebd0db91433c39855dae765787ec68157faffba4cdb05a0600af4652e3e35da939e0bad8ef1e
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/devel/pahole/pahole.git
   pahole_version: 1.31


### PR DESCRIPTION
OpenSSL 3.6.2 includes fixes for 7 CVEs:
- CVE-2026-28386
- CVE-2026-28387
- CVE-2026-28388
- CVE-2026-28389
- CVE-2026-28390
- CVE-2026-31789
- CVE-2026-31790

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
