### PR TITLE
feat: update Go to 1.26.3

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -5,7 +5,7 @@
 format: v1alpha2
 
 vars:
-  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v1.14.0-alpha.0-6-g08ac561
+  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v1.14.0-alpha.0-7-gda3298a
 
   # renovate: datasource=github-tags depName=argp-standalone/argp-standalone
   argp_standalone_version: 1.5.0
@@ -188,9 +188,9 @@ vars:
   libuv_sha512: c23bb26f8fdcf678dbf14bcee9855830927a40b8ae64dfa287ef1e910f37ad30cb868ecdeaad6f7b2bf3f3fccca1a7282a31b22c547206b672f923d0651f5b0c
 
   # renovate: datasource=github-releases extractVersion=^llvmorg-(?<version>.*)$ depName=llvm/llvm-project
-  llvm_version: 22.1.4
-  llvm_sha256: 3e68c90dda630c27d41d201e37b8bbf5222e39b273dec5ca880709c69e0a07d4
-  llvm_sha512: 9f9e84110a4bb0f0dd296eaed4acb4fd3a58838efe62bb88671399440ba4750ba8bd7e6d072e61a9946e38e5c9d5e50575b95964850769c51cd517bdf7425bb8
+  llvm_version: 22.1.5
+  llvm_sha256: 7972b87b705a003ce70ab55f9f0fb495d156887cba0eb296d284731139118e2c
+  llvm_sha512: 68de113906ec0c843a9346ecd06bff352146869f1f28b5600ff907125d77202692b6f68bd169bcd74ae5b82e0ad5548ea99c2405540abea36880d80e373744ff
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.savannah.gnu.org/m4.git
   m4_version: 1.4.21


### PR DESCRIPTION
Go bump via toolchain.

Also bump LLVM to 22.1.5.