### PR TITLE
chore: update dependencies for 1.12.8

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,20 @@
         ":semanticCommitScopeDisabled",
         "schedule:earlyMondays"
     ],
+    "customDatasources": {
+        "bc": {
+            "defaultRegistryUrlTemplate": "https://ftp.gnu.org/gnu/bc/",
+            "format": "html"
+        },
+        "ca-certificates": {
+            "defaultRegistryUrlTemplate": "https://curl.se/docs/caextract.html",
+            "format": "html"
+        },
+        "gmp": {
+            "defaultRegistryUrlTemplate": "https://ftp.gnu.org/gnu/gmp/",
+            "format": "html"
+        }
+    },
     "customManagers": [
         {
             "customType": "regex",
@@ -114,12 +128,6 @@
             "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.?(?<patch>\\d+)?\\.?(?<build>\\d+)?$",
             "matchPackageNames": [
                 "https://salsa.debian.org/clint/fakeroot.git"
-            ]
-        },
-        {
-            "versioning": "regex:^(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)$",
-            "matchPackageNames": [
-                "homebrew/ca-certificates"
             ]
         }
     ],

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-05-18T11:56:40Z by kres 85aa5ad.
+# Generated on 2026-05-18T12:02:39Z by kres 85aa5ad.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-22T11:11:05Z by kres 7d181e7.
+# Generated on 2026-05-18T11:56:40Z by kres 85aa5ad.
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
@@ -87,7 +87,7 @@ jobs:
           make  PUSH=true
       - name: Retrieve PR labels
         id: retrieve-pr-labels
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # version: v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # version: v9.0.0
         with:
           retries: "3"
           script: |
@@ -106,14 +106,14 @@ jobs:
           make release-notes
       - name: Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # version: v2.6.1
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # version: v3.0.0
         with:
           body_path: _out/RELEASE_NOTES.md
           draft: "true"
   reproducibility:
     runs-on:
       group: pkgs
-    if: contains(fromJSON(needs.default.outputs.labels), 'integration/reproducibility')
+    if: contains(fromJSON(needs.default.outputs.labels || '[]'), 'integration/reproducibility')
     needs:
       - default
     steps:

--- a/.github/workflows/slack-notify-ci-failure.yaml
+++ b/.github/workflows/slack-notify-ci-failure.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-05-18T11:56:40Z by kres 85aa5ad.
+# Generated on 2026-05-18T12:02:39Z by kres 85aa5ad.
 
 "on":
   workflow_run:

--- a/.github/workflows/slack-notify-ci-failure.yaml
+++ b/.github/workflows/slack-notify-ci-failure.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-22T11:11:05Z by kres 7d181e7.
+# Generated on 2026-05-18T11:56:40Z by kres 85aa5ad.
 
 "on":
   workflow_run:
@@ -18,7 +18,7 @@ jobs:
     if: github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.event != 'pull_request'
     steps:
       - name: Slack Notify
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # version: v3.0.1
+        uses: slackapi/slack-github-action@03ea5433c137af7c0495bc0cad1af10403fc800c # version: v3.0.2
         with:
           method: chat.postMessage
           payload: |

--- a/.github/workflows/slack-notify.yaml
+++ b/.github/workflows/slack-notify.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-05-18T11:56:40Z by kres 85aa5ad.
+# Generated on 2026-05-18T12:02:39Z by kres 85aa5ad.
 
 "on":
   workflow_run:

--- a/.github/workflows/slack-notify.yaml
+++ b/.github/workflows/slack-notify.yaml
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-22T11:11:05Z by kres 7d181e7.
+# Generated on 2026-05-18T11:56:40Z by kres 85aa5ad.
 
 "on":
   workflow_run:
@@ -24,7 +24,7 @@ jobs:
         run: |
           echo pull_request_number=$(gh pr view -R ${{ github.repository }} ${{ github.event.workflow_run.head_repository.owner.login }}:${{ github.event.workflow_run.head_branch }} --json number --jq .number) >> $GITHUB_OUTPUT
       - name: Slack Notify
-        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # version: v3.0.1
+        uses: slackapi/slack-github-action@03ea5433c137af7c0495bc0cad1af10403fc800c # version: v3.0.2
         with:
           method: chat.postMessage
           payload: |

--- a/.kres.yaml
+++ b/.kres.yaml
@@ -68,6 +68,13 @@ spec:
     - matchPackageNames:
         - https://salsa.debian.org/clint/fakeroot.git
       versioning: 'regex:^(?<major>\d+)\.(?<minor>\d+)\.?(?<patch>\d+)?\.?(?<build>\d+)?$'
-    - matchPackageNames:
-        - homebrew/ca-certificates
-      versioning: 'regex:^(?<major>\d+)-(?<minor>\d+)-(?<patch>\d+)$'
+  customDatasources:
+    bc:
+      defaultRegistryUrlTemplate: https://ftp.gnu.org/gnu/bc/
+      format: html
+    gmp:
+      defaultRegistryUrlTemplate: https://ftp.gnu.org/gnu/gmp/
+      format: html
+    ca-certificates:
+      defaultRegistryUrlTemplate: https://curl.se/docs/caextract.html
+      format: html

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2026-04-22T11:11:05Z by kres 7d181e7.
+# Generated on 2026-05-18T11:56:40Z by kres 85aa5ad.
 
 # common variables
 

--- a/Pkgfile
+++ b/Pkgfile
@@ -27,6 +27,7 @@ vars:
   bash_sha256: 0d5cd86965f869a26cf64f4b71be7b96f90a3ba8b3d74e27e8e9d9d5550f31ba
   bash_sha512: 426702c8b0fb9e0c9956259973ce5b657890fd47f4f807a64febf20077bb48d0b91474ed6e843d2ef277186b46c5fffa79b808da9b48d4ec027d5e2de1b28ed8
 
+  # renovate: datasource=custom.bc extractVersion=^bc-(?<version>.+)\.tar\.gz$ versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.?(?<patch>\d+)?$ depName=bc
   bc_version: 1.08.2
   bc_sha256: ae470fec429775653e042015edc928d07c8c3b2fc59765172a330d3d87785f86
   bc_sha512: 0876a4c5bfc23da79479519c6a8e03ac9f59ae54077eb71ffdcc6ddaccb76c4b7595b088e89e6ad82d833c072eeff5b378178084276584813c00eedace4c6f8c
@@ -41,10 +42,10 @@ vars:
   bzip2_sha256: ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269
   bzip2_sha512: 083f5e675d73f3233c7930ebe20425a533feedeaaa9d8cc86831312a6581cefbe6ed0d08d2fa89be81082f2a5abdabca8b3c080bf97218a1bd59dc118a30b9f3
 
-  # renovate: datasource=repology depName=homebrew/ca-certificates
-  ca_certificates_version: 2025-12-02
-  ca_certificates_sha256: f1407d974c5ed87d544bd931a278232e13925177e239fca370619aba63c757b4
-  ca_certificates_sha512: aef293e084ef15a55a4f9dee395ee4bbbadea1f5a49c0590e0ff67a0630b5298d2bc79699ab95d70be0d2d06f9f1e55fe676b3e1d5ff912df88f2d6bff0d5736
+  # renovate: datasource=custom.ca-certificates extractVersion=^/ca/cacert-(?<version>.+)\.pem$ versioning=regex:^(?<major>\d+)-(?<minor>\d+)-(?<patch>\d+)$ depName=ca-certificates
+  ca_certificates_version: 2026-03-19
+  ca_certificates_sha256: b6e66569cc3d438dd5abe514d0df50005d570bfc96c14dca8f768d020cb96171
+  ca_certificates_sha512: efe2d37cbb60532f7b9be99c3c2826b97c55661b7880f6a108c30ee1ebf270f3dee69de164f241def51fccbe2f3d95cf6882bcc59ba72f48a2a316b81f03bb55
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=https://gitlab.kitware.com/cmake/cmake.git
   cmake_version: 4.1.2
@@ -121,8 +122,7 @@ vars:
   git_sha256: 233d7143a2d58e60755eee9b76f559ec73ea2b3c297f5b503162ace95966b4e3
   git_sha512: 547c3e522d9e6a2c2ccab24ee0c7f4f2d29878759563356e3a2ae9675884b7044ce5a236803170a203b79443760eb18a7089eec02bd105316e3ab045ab7603a7
 
-  # official source code uses mercurial https://gmplib.org/devel/repo-usage, so falling back to a GitHub mirror,
-  # renovate: datasource=github-tags extractVersion=^v(?<version>.*)$ depName=alisw/GMP
+  # renovate: datasource=custom.gmp extractVersion=^gmp-(?<version>.+)\.tar\.xz$ depName=gmp
   gmp_version: 6.3.0
   gmp_sha256: a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898
   gmp_sha512: e85a0dab5195889948a3462189f0e0598d331d3457612e2d3350799dba2e244316d256f8161df5219538eb003e4b5343f989aaa00f96321559063ed8c8f29fd2

--- a/Pkgfile
+++ b/Pkgfile
@@ -5,7 +5,7 @@
 format: v1alpha2
 
 vars:
-  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v1.12.0-10-gec7c6e8
+  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v1.12.0-11-gce759f6
 
   # renovate: datasource=github-tags depName=argp-standalone/argp-standalone
   argp_standalone_version: 1.5.0
@@ -43,9 +43,9 @@ vars:
   bzip2_sha512: 083f5e675d73f3233c7930ebe20425a533feedeaaa9d8cc86831312a6581cefbe6ed0d08d2fa89be81082f2a5abdabca8b3c080bf97218a1bd59dc118a30b9f3
 
   # renovate: datasource=custom.ca-certificates extractVersion=^/ca/cacert-(?<version>.+)\.pem$ versioning=regex:^(?<major>\d+)-(?<minor>\d+)-(?<patch>\d+)$ depName=ca-certificates
-  ca_certificates_version: 2026-03-19
-  ca_certificates_sha256: b6e66569cc3d438dd5abe514d0df50005d570bfc96c14dca8f768d020cb96171
-  ca_certificates_sha512: efe2d37cbb60532f7b9be99c3c2826b97c55661b7880f6a108c30ee1ebf270f3dee69de164f241def51fccbe2f3d95cf6882bcc59ba72f48a2a316b81f03bb55
+  ca_certificates_version: 2026-05-14
+  ca_certificates_sha256: 86a1f3366afac7c6f8ae9f3c779ac221129328c43f0ab2b8817eb2f362a5025c
+  ca_certificates_sha512: 161cb987d3da5aca72083f346c3b51394cfe76d52c263d8c1c611e29944c8798aae054f2ef2f7109e035e3a1e27102d8e6d520cf34f7c5a951c9dbb280b29620
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=https://gitlab.kitware.com/cmake/cmake.git
   cmake_version: 4.1.2


### PR DESCRIPTION
Update toolchain to v1.12.0-11-gce759f6
Update ca-certificates to 2026-05-14

Cherry picks:
- https://github.com/siderolabs/tools/pull/528
