### PR TITLE
fix: add SBOM for zstd library

### DIFF
--- a/tools-zstd/pkg.yaml
+++ b/tools-zstd/pkg.yaml
@@ -25,6 +25,14 @@ steps:
     test:
       - |
         fhs-validator /rootfs
+    sbom:
+      outputPath: /rootfs/usr/share/spdx/zstd.spdx.json
+      name: zstd
+      version: {{ .zstd_version }}
+      cpes:
+        - cpe:2.3:a:facebook:zstandard:{{ .zstd_version }}:*:*:*:*:*:*:*
+      licenses:
+        - BSD-3-Clause OR GPL-2.0-only
 finalize:
   - from: /rootfs
     to: /


### PR DESCRIPTION
It was missing previously.