### PR TITLE
fix: add proper name for zlib-ng sbom

### DIFF
--- a/tools-zlib-ng/pkg.yaml
+++ b/tools-zlib-ng/pkg.yaml
@@ -29,6 +29,7 @@ steps:
     sbom:
       outputPath: /rootfs/usr/share/spdx/zlib-ng.spdx.json
       version: {{ .zlib_ng_version }}
+      name: zlib-ng
       cpes:
         - cpe:2.3:a:zlib-ng:zlib-ng:{{ .zlib_ng_version }}:*:*:*:*:*:*:*
       licenses:


### PR DESCRIPTION
Otherwise it appears as `tools-zlib-ng`, but we want just `zlib-ng`.