### PR TITLE
feat: bump go to 1.26.4

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -5,7 +5,7 @@
 format: v1alpha2
 
 vars:
-  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v1.13.0-1-g4048daf
+  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v1.13.0-2-g108ceba
 
   # renovate: datasource=github-tags depName=argp-standalone/argp-standalone
   argp_standalone_version: 1.5.0


### PR DESCRIPTION
Bump toolchain image for Go 1.26.4

See: siderolabs/toolchain#205