### PR TITLE
feat: bump OpenSSL to 3.6.3

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -243,9 +243,9 @@ vars:
   ninja_sha512: c0b401b4db91a2eea01a474ee979b2c6f1daa97b4c8d1f856871ce5f6d567c4b26d6246bc57e2a5f914329302abcd9c00ab0d4394a25f2ad502b6b00a07903d2
 
   # renovate: datasource=github-releases extractVersion=^openssl-(?<version>.*)$ depName=openssl/openssl
-  openssl_version: 3.6.2
-  openssl_sha256: aaf51a1fe064384f811daeaeb4ec4dce7340ec8bd893027eee676af31e83a04f
-  openssl_sha512: 46549ed4d6b0160adfa3e1406bc16f3083a7f3c85bdda289c1dbebd0db91433c39855dae765787ec68157faffba4cdb05a0600af4652e3e35da939e0bad8ef1e
+  openssl_version: 3.6.3
+  openssl_sha256: 243a86649cf6f23eeb6a2ff2456e09e5d77dd9018a54d3d96b0c6bdd6ba6c7f1
+  openssl_sha512: 4179ad56f285fd27a1c7b294472afdca588e915d4f8a9610e461f34f0678004aebe32e88434ae536a63a7c9aff6607702a3b341e2faacb7899c27d6def4cc92d
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/devel/pahole/pahole.git
   pahole_version: 1.31


### PR DESCRIPTION
Bump OpenSSL to 3.6.3 to silence CVE warnings

Silences these:

* CVE-2026-45447
* CVE-2026-9076
* CVE-2026-7383
* CVE-2026-34180
* CVE-2026-42766
* CVE-2026-42767
* CVE-2026-42764
* CVE-2026-42765
* CVE-2026-45445
* CVE-2026-34183
* CVE-2026-35188
* CVE-2026-45446
* CVE-2026-42769
* CVE-2026-42768
* CVE-2026-34182
* CVE-2026-42770
* CVE-2026-34181