### PR TITLE
chore: update dependencies 2026-06-16

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -73,9 +73,9 @@ vars:
   diffutils_sha512: 10b17cf1dcdfa9ca0e5db91d62c4a079ebe9fd7eafa3aaebd4eb7e6206e4d753f348496622aa281e1bd7f7fcde65ce4a886dcc4acbb59332ef980f224197b4e4
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/utils/dtc/dtc.git
-  dtc_version: 1.8.0
-  dtc_sha256: b298e24ce4824bd2e2af60cf6a3d2815e555b3e44c431eadad0b52798c83a833
-  dtc_sha512: 3fe422f1a1d5f920b96d2336f757a4b9ce1363b1d6595e213e4d6a2bcaf7bf30cc75648195e1540b72382c34031c74231fa741a4edb0a32f74d2914f0f487c44
+  dtc_version: 1.8.1
+  dtc_sha256: 23526015a6f1550e0541a53fe7acea1b5a11e3697cdf3a3bdc076abc38f6045d
+  dtc_sha512: 9a2987aab1e3be91b71a72e5aea7a4e3f88e66521e68fea25345f5e1f86189c0ed82668e31d4ce7869cb0e0277289ffa3b62bc2a002f2d18849be84aa4fab757
 
   # renovate: datasource=github-tags extractVersion=^v(?<version>.*)$ depName=davea42/libdwarf-code
   dwarfutils_version: 2.3.1
@@ -173,9 +173,9 @@ vars:
   libtasn1_sha512: 6a581c4c072b168bf29a0dec7e59a9329a798e392b7d1033791d0e3166a5d1164e2a7065373a84018d500a01563657900c318b1fd437c227c3174b754f9998d3
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.savannah.gnu.org/libunistring.git
-  libunistring_version: 1.4.1
-  libunistring_sha256: 67d88430892527861903788868c77802a217b0959990f7449f2976126a307763
-  libunistring_sha512: e0838b4324193aa927c6a3d647b9a482f12e11525d0cf2b5f0e6cf6b9afc9f2ee751d39d72e3c980bac3fc91e0d9d043c4a1c5662dde3cc26c52312d224d80f0
+  libunistring_version: 1.4.2
+  libunistring_sha256: 5b46e74377ed7409c5b75e7a96f95377b095623b689d8522620927964a41499c
+  libunistring_sha512: 0215f7f40f426227eca5174140654a3fa43ac1520eeb212c2ba08043470f905687b2703afdda12e9635359a6187643900136b6bb11b422bd7567d17ca71b555f
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.savannah.gnu.org/libtool.git
   libtool_version: 2.5.4
@@ -188,9 +188,9 @@ vars:
   libuv_sha512: c23bb26f8fdcf678dbf14bcee9855830927a40b8ae64dfa287ef1e910f37ad30cb868ecdeaad6f7b2bf3f3fccca1a7282a31b22c547206b672f923d0651f5b0c
 
   # renovate: datasource=github-releases extractVersion=^llvmorg-(?<version>.*)$ depName=llvm/llvm-project
-  llvm_version: 22.1.6
-  llvm_sha256: 6e0b376a1f6d9873e7dfb09ae6e04b9c7024400f01733fa4c29be69d5c138bc2
-  llvm_sha512: 39ee3a66b92abe4eed5f9db086f6279faa72d8a3fe1beee8897da2dcc8b6982d169054b394995090c9cc6519f50a03a7fc465905dda3c61eb1063b9ba4696b0c
+  llvm_version: 22.1.7
+  llvm_sha256: 5cc4a3f12bba50b6bdfb4b61bdc852117a0ff2517807c3902fc13267fb93562e
+  llvm_sha512: b7e56121cd6cb24085185ca0b621fec272dd9aa237c49a901043a9a4c31fdbc1ff33e650891d9786cd9495c006e87d4553ac36b518c864c75e99a80e40771bfd
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.savannah.gnu.org/m4.git
   m4_version: 1.4.21
@@ -279,9 +279,9 @@ vars:
   pyelftools_sha512: 7f4ef37da7fda75125cb95ced2f3084848943592eff7deae7ae917508f1cd5281c96960ee3bbc6e503e71a4e2196622cd68cc67e3df1f4cd99b9b675f14fd58c
 
   # renovate: datasource=github-tags extractVersion=^v(?<version>.*)$ depName=python/cpython
-  python_version: 3.14.5
-  python_sha256: 7e32597b99e5d9a39abed35de4693fa169df3e5850d4c334337ffd6a19a36db6
-  python_sha512: efbaf629703cd004f6b7bc75fb16df794185589adaf8807cd45928f212271045a399df3cd9573e47c8708fb5c5002f9d4efe4e41dde4313b81a3e9d73158769f
+  python_version: 3.14.6
+  python_sha256: 143b1dddefaec3bd2e21e3b839b34a2b7fb9842272883c576420d605e9f30c63
+  python_sha512: 90a82f46c28f0fca613b67358fdc57c145ab05d20fb56bf3bc0c9e4e54947c7d30fbaa6856c41a41909237a9e601d1a7d19579d4b25c7a784ebcfe9012defc41
 
   # renovate: datasource=github-releases versioning=python depName=pypa/build
   python_build_version: 1.5.0


### PR DESCRIPTION
| Package | Update | Change |
|---|---|---|
| git://git.kernel.org/pub/scm/utils/dtc/dtc.git | patch | `1.8.0` → `1.8.1` |
| git://git.savannah.gnu.org/libunistring.git | patch | `1.4.1` → `1.4.2` |
| [llvm/llvm-project](https://redirect.github.com/llvm/llvm-project) | patch | `22.1.6` → `22.1.7` |
| [python/cpython](https://redirect.github.com/python/cpython) | patch | `3.14.5` → `3.14.6` |

- Libtool skipped since the v2.6.1 release tag is not available through
  the mirror at the moment.
- OpenSSL (4.x) skipped since it breaks the build due to Python 3.14
  incompatibility. OpenSSL 4.x support will be introduced with Python 3.15, which is not out yet.
