### PR TITLE
chore: switch texinfo to ftp.gnu.org

### DIFF
--- a/texinfo/pkg.yaml
+++ b/texinfo/pkg.yaml
@@ -5,7 +5,7 @@ dependencies:
   - stage: perl
 steps:
   - sources:
-      - url: https://ftpmirror.gnu.org/gnu/texinfo/texinfo-{{ .texinfo_version }}.tar.xz
+      - url: https://ftp.gnu.org/gnu/texinfo/texinfo-{{ .texinfo_version }}.tar.xz
         destination: texinfo.tar.xz
         sha256: "{{ .texinfo_sha256 }}"
         sha512: "{{ .texinfo_sha512 }}"


### PR DESCRIPTION
ftpmirror.gnu.org auto redir tends to fail. Spotted and first fixed through https://github.com/siderolabs/tools/pull/547

https://lists.gnu.org/archive/html/info-gnu/2024-12/msg00007.html