### PR TITLE
chore: update toolchain for release 1.12

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -5,7 +5,7 @@
 format: v1alpha2
 
 vars:
-  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v1.12.0-13-gd5c3eea
+  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v1.12.0-14-g82698c2
 
   # renovate: datasource=github-tags depName=argp-standalone/argp-standalone
   argp_standalone_version: 1.5.0


### PR DESCRIPTION
Update toolchain image to match `release-1.12` HEAD:

https://github.com/siderolabs/toolchain/commit/82698c2bfebb6dd6aee4c2bb901547c88505950b