### PR TITLE
chore: bump pkgfile bldr to v0.6.1

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -1,4 +1,4 @@
-# syntax = ghcr.io/siderolabs/bldr:v0.6.0
+# syntax = ghcr.io/siderolabs/bldr:v0.6.1
 
 # Sync bldr image with Makefile
 


### PR DESCRIPTION
Was bumped in Makefile through Kres, but still missing the update in Pkgfile.