### PR TITLE
chore: (1.12) restore bldr to v0.5.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ SOURCE_DATE_EPOCH := $(shell git log $(INITIAL_COMMIT_SHA) --pretty=%ct)
 
 # sync bldr image with pkgfile
 
-BLDR_RELEASE := v0.6.1
+BLDR_RELEASE := v0.5.6
 BLDR_IMAGE := ghcr.io/siderolabs/bldr:$(BLDR_RELEASE)
 BLDR := docker run --rm --user $(shell id -u):$(shell id -g) --volume $(PWD):/src --entrypoint=/bldr $(BLDR_IMAGE) --root=/src
 

--- a/Pkgfile
+++ b/Pkgfile
@@ -1,4 +1,4 @@
-# syntax = ghcr.io/siderolabs/bldr:v0.6.1
+# syntax = ghcr.io/siderolabs/bldr:v0.5.6
 
 # Sync bldr image with Makefile
 


### PR DESCRIPTION
Keeps other CI/QoL changes from `make rekres`, downgrades `bldr` to `v0.5.6`, as the newer versions bring in new compilation flags.

https://talossystems.slack.com/archives/C05348FENHG/p1784134656286129