### PR TITLE
feat: enable static libs for pcre2

### DIFF
--- a/tools-pcre2/pkg.yaml
+++ b/tools-pcre2/pkg.yaml
@@ -22,7 +22,7 @@ steps:
           --enable-pcre232 \
           --enable-pcre2grep-libz \
           --enable-pcre2grep-libbz2 \
-          --disable-static
+          --enable-static # this allows us to drop pcre2 from extensions
     build:
       - |
         cd build


### PR DESCRIPTION
enable static libs for pcre2, this allows us to
drop pcre2 from for qemu guest agent, since it's
built statically.