### PR TITLE
chore: update toolchain

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -5,7 +5,7 @@
 format: v1alpha2
 
 vars:
-  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v1.13.0-4-gd4c09bb
+  TOOLCHAIN_IMAGE: ghcr.io/siderolabs/toolchain:v1.13.0-6-g3d4094f
 
   # renovate: datasource=github-tags depName=argp-standalone/argp-standalone
   argp_standalone_version: 1.5.0


### PR DESCRIPTION
Update toolchain to v1.13.0-6-g3d4094f

Signed-off-by: Mateusz Urbanek <mateusz.urbanek@siderolabs.com>
