### PR TITLE
chore: bump util-linux to 2.42.3

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -373,9 +373,9 @@ vars:
   texinfo_sha512: fb1a16df67f870e79c31f4b96d8431d9c944eb84e5aa71e9d94890417ce63047918d55620fa63bd582232c47e9b412a6f95a11a2479f53f40e92e49bc018d926
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.kernel.org/pub/scm/utils/util-linux/util-linux.git
-  util_linux_version: 2.42.2
-  util_linux_sha256: 03a05d3adf9602ef128f2da05b84b3205ce60c351e5737c0370f74000679ce8a
-  util_linux_sha512: 7415add0be2930654e322830808dde03ff6d511bd357f0679e6b6287a13ca79fe58ce4ac05edef86b76fb381b3a36ca2da9d3c31b5dc0a1d889c203156a57277
+  util_linux_version: 2.42.3
+  util_linux_sha256: 66ac7c0e725278eb2b039e3104f2c91119341d941b41bac7a285c695f940bd57
+  util_linux_sha512: 2a307943d4fbb34ac02131e10ff7260f181dd706b21e68a891d25d6eb30476a612bcc19b674bb2256283c9c716146e0d79909f37324efc9aa9d45a44e0d58988
 
   # renovate: datasource=github-releases depName=tukaani-project/xz
   xz_version: v5.8.3

--- a/tools-util-linux/patches/fileutils-include.patch
+++ b/tools-util-linux/patches/fileutils-include.patch
@@ -1,0 +1,36 @@
+From 7e2e0108000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Karel Zak <kzak@redhat.com>
+Subject: [PATCH] libmount: add missing fileutils.h include to hook_idmap.c
+
+The hook_idmap.c uses RESOLVE_NO_SYMLINKS (added by commit fb8e26535)
+but does not include fileutils.h, which provides the fallback #define
+for this constant.
+
+On Fedora (glibc 2.40+), this is masked because glibc's
+<bits/fcntl-linux.h> transitively includes <linux/openat2.h>, which
+defines RESOLVE_NO_SYMLINKS. On Ubuntu (and other distros with older
+glibc), <fcntl.h> does not pull in openat2.h, so the build fails:
+
+  hook_idmap.c:335:33: error: 'RESOLVE_NO_SYMLINKS' undeclared
+
+Fixes: fb8e26535 ("libmount: pin source path with openat2() for restricted users")
+Signed-off-by: Karel Zak <kzak@redhat.com>
+---
+ libmount/src/hook_idmap.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/libmount/src/hook_idmap.c b/libmount/src/hook_idmap.c
+index d9cfa16277b..a71c620f073 100644
+--- a/libmount/src/hook_idmap.c
++++ b/libmount/src/hook_idmap.c
+@@ -23,6 +23,7 @@
+
+ #include "strutils.h"
+ #include "all-io.h"
++#include "fileutils.h"
+ #include "namespace.h"
+
+ #include "mountP.h"
+--
+2.42.3
+

--- a/tools-util-linux/pkg.yaml
+++ b/tools-util-linux/pkg.yaml
@@ -3,6 +3,7 @@ variant: scratch
 dependencies:
   - stage: base
   - stage: bash
+  - stage: patch
 steps:
   - sources:
       - url: https://www.kernel.org/pub/linux/utils/util-linux/v{{ regexReplaceAll ".\\d+$" .util_linux_version "${1}" }}/util-linux-{{  regexReplaceAll "\\.0$" .util_linux_version "${1}" }}.tar.xz
@@ -12,6 +13,8 @@ steps:
     prepare:
       - |
         tar -xJf util-linux.tar.xz --strip-components=1
+
+        patch -p1 < /pkg/patches/fileutils-include.patch
       - |
         mkdir build
         cd build


### PR DESCRIPTION
Comes after https://github.com/siderolabs/tools/pull/582